### PR TITLE
Fix sales last week info POS

### DIFF
--- a/apps/dashboard/src/modules/seller/views/POSInfoView.vue
+++ b/apps/dashboard/src/modules/seller/views/POSInfoView.vue
@@ -46,12 +46,11 @@ import { type ContainerWithProductsResponse, ReportResponse } from '@sudosos/sud
 import { usePointOfSaleStore } from '@/stores/pos.store';
 import ContainerCard from '@/components/container/ContainersCard.vue';
 import router from '@/router';
-import apiService, { DEFAULT_PAGINATION_MAX } from '@/services/ApiService';
+import apiService from '@/services/ApiService';
 import { useContainerStore } from '@/stores/container.store';
 import MutationPOSCard from '@/components/mutations/MutationsPOS.vue';
 import CardComponent from '@/components/CardComponent.vue';
 import POSSettingsCard from '@/modules/seller/components/POSSettingsCard.vue';
-import { useTransactionStore } from '@/stores/transaction.store';
 import { formatPrice } from 'sudosos-dashboard/src/utils/formatterUtils';
 import { getRelation, isAllowed } from '@/utils/permissionUtils';
 import PageContainer from '@/layout/PageContainer.vue';

--- a/apps/dashboard/src/modules/seller/views/POSInfoView.vue
+++ b/apps/dashboard/src/modules/seller/views/POSInfoView.vue
@@ -42,7 +42,7 @@ import type {
 // eslint-disable-next-line import/no-named-as-default
 import Dinero from 'dinero.js';
 import { useI18n } from 'vue-i18n';
-import { type ContainerWithProductsResponse, ReportResponse } from '@sudosos/sudosos-client/src/api';
+import { type ContainerWithProductsResponse, type ReportResponse } from '@sudosos/sudosos-client/src/api';
 import { usePointOfSaleStore } from '@/stores/pos.store';
 import ContainerCard from '@/components/container/ContainersCard.vue';
 import router from '@/router';
@@ -115,9 +115,10 @@ watch(
       )
       .then((res) => {
         const data: ReportResponse = res.data;
-        const posReport = data.data.pos.find((r) => r.pos.id === p.value.id);
+        if (!data.data.pos) return;
+        const posReport = data.data.pos.find((r) => r.pos.id === p.value?.id);
         if (!posReport) return;
-        totalSales.value = Dinero(posReport.totalInclVat);
+        totalSales.value = Dinero(posReport.totalInclVat as Dinero.Options);
       });
   },
 );

--- a/apps/dashboard/src/modules/seller/views/POSInfoView.vue
+++ b/apps/dashboard/src/modules/seller/views/POSInfoView.vue
@@ -42,7 +42,7 @@ import type {
 // eslint-disable-next-line import/no-named-as-default
 import Dinero from 'dinero.js';
 import { useI18n } from 'vue-i18n';
-import { type ContainerWithProductsResponse } from '@sudosos/sudosos-client/src/api';
+import { type ContainerWithProductsResponse, ReportResponse } from '@sudosos/sudosos-client/src/api';
 import { usePointOfSaleStore } from '@/stores/pos.store';
 import ContainerCard from '@/components/container/ContainersCard.vue';
 import router from '@/router';
@@ -107,22 +107,19 @@ const formattedTotalSales = computed(() => {
 watch(
   () => canLoadTransactions.value,
   async (canLoad) => {
-    if (!canLoad) return;
-    const transactionStore = useTransactionStore();
-    const transactionsInLastWeek = (
-      await transactionStore.fetchTransactionsFromPointOfSale(
-        apiService,
-        id.value!,
+    if (!canLoad || !p.value?.owner) return;
+    await apiService.user
+      .getUsersSalesReport(
+        p.value.owner.id,
         new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
         new Date().toISOString(),
-        DEFAULT_PAGINATION_MAX,
-        0,
       )
-    ).data.records;
-
-    for (const transaction of transactionsInLastWeek) {
-      totalSales.value = totalSales.value.add(Dinero(transaction.value as Dinero.Options));
-    }
+      .then((res) => {
+        const data: ReportResponse = res.data;
+        const posReport = data.data.pos.find((r) => r.pos.id === p.value.id);
+        if (!posReport) return;
+        totalSales.value = Dinero(posReport.totalInclVat);
+      });
   },
 );
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

This was slightly unstable. Improved reactivity and now fetches this info from the sales report instead.


Before:
![image](https://github.com/user-attachments/assets/87288390-d6ec-4e56-a0ee-d087a1959163)

After:
![image](https://github.com/user-attachments/assets/d1deef75-7097-4336-bbfa-ebe69042cdc0)

So a bit more than 14x faster. It's now so fast that the transaction table is significantly slower.

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_