### PR TITLE
feat: add preload composable and option to mutations balance

### DIFF
--- a/apps/dashboard/src/components/mutations/MutationsBalance.vue
+++ b/apps/dashboard/src/components/mutations/MutationsBalance.vue
@@ -91,7 +91,7 @@
 <script lang="ts" setup>
 import DataTable, { type DataTablePageEvent } from 'primevue/datatable';
 import Column from 'primevue/column';
-import { computed, nextTick, onMounted, type Ref, ref } from 'vue';
+import { computed, onMounted, type Ref, ref } from 'vue';
 import { useUserStore } from '@sudosos/sudosos-frontend-common';
 import type { PaginatedFinancialMutationResponse } from '@sudosos/sudosos-client';
 import { useI18n } from 'vue-i18n';
@@ -100,13 +100,12 @@ import { type FinancialMutation, FinancialMutationType, parseFinancialMutations 
 import ModalMutation from '@/components/mutations/mutationmodal/ModalMutation.vue';
 import { isIncreasingTransfer, isFine } from '@/utils/mutationUtils';
 import { useSizeBreakpoints } from '@/composables/sizeBreakpoints';
-import { useMutationDetails } from '@/composables/mutationDetails';
 import { usePrefetchMutationDetails } from '@/composables/preloadMutationDetails';
 
 const { t, locale } = useI18n();
 const userStore = useUserStore();
 const { isMd } = useSizeBreakpoints();
-const { preload } = usePrefetchMutationDetails();
+const pl = usePrefetchMutationDetails().preload;
 
 const props = defineProps<{
   getMutations: (take: number, skip: number) => Promise<PaginatedFinancialMutationResponse | undefined>;
@@ -133,7 +132,7 @@ async function refresh() {
   totalRecords.value = newTransactions._pagination.count || 0;
   isLoading.value = false;
 
-  if (props.preload) void preload(mutations.value);
+  if (props.preload) void pl(mutations.value);
 }
 
 onMounted(refresh);

--- a/apps/dashboard/src/components/mutations/MutationsBalance.vue
+++ b/apps/dashboard/src/components/mutations/MutationsBalance.vue
@@ -131,11 +131,13 @@ async function refresh() {
   mutations.value = parseFinancialMutations(newTransactions);
   totalRecords.value = newTransactions._pagination.count || 0;
   isLoading.value = false;
-
-  if (props.preload) void pl(mutations.value);
 }
 
-onMounted(refresh);
+onMounted(async () => {
+  await refresh().then(() => {
+    if (props.preload) void pl(mutations.value);
+  });
+});
 
 async function onPage(event: DataTablePageEvent) {
   const newTransactions = await props.getMutations(event.rows, event.first);

--- a/apps/dashboard/src/composables/mutationDetails.ts
+++ b/apps/dashboard/src/composables/mutationDetails.ts
@@ -8,7 +8,7 @@ import { FinancialMutationType } from '@/utils/mutationUtils';
 import { getProductsOfTransaction } from '@/utils/transactionUtil';
 import { UserRole } from '@/utils/rbacUtils';
 
-export function useMutationDetails(type: Ref<FinancialMutationType>, id: Ref<number>) {
+export function useMutationDetails(type: Ref<FinancialMutationType>, id: Ref<number>, immediate: boolean = true) {
   const transactionStore = useTransactionStore();
   const transferStore = useTransferStore();
   const { current } = storeToRefs(useUserStore());
@@ -56,7 +56,7 @@ export function useMutationDetails(type: Ref<FinancialMutationType>, id: Ref<num
   });
 
   // Fetch on mount & whenever id/type change
-  watch([type, id], fetchMutation, { immediate: true });
+  watch([type, id], fetchMutation, { immediate });
 
   return {
     isLoading,

--- a/apps/dashboard/src/composables/preloadMutationDetails.ts
+++ b/apps/dashboard/src/composables/preloadMutationDetails.ts
@@ -16,7 +16,7 @@ export function usePrefetchMutationDetails() {
     for (const mutation of mutations) {
       if (!mutation) continue;
       // useMutationDetails expects Refs (type, id)
-      const { fetchMutation } = useMutationDetails(ref(mutation.type), ref(mutation.id));
+      const { fetchMutation } = useMutationDetails(ref(mutation.type), ref(mutation.id), false);
       promises.push(fetchMutation());
     }
     await Promise.all(promises);

--- a/apps/dashboard/src/composables/preloadMutationDetails.ts
+++ b/apps/dashboard/src/composables/preloadMutationDetails.ts
@@ -1,0 +1,26 @@
+import { nextTick, ref } from 'vue';
+import { useMutationDetails } from '@/composables/mutationDetails';
+import type { FinancialMutation } from '@/utils/mutationUtils';
+
+/**
+ * Prefetches the details for a given list of base mutations.
+ */
+export function usePrefetchMutationDetails() {
+  /**
+   * @param mutations Array of base FinancialMutation objects (should have id and type)
+   * @returns Promise that resolves when all visible details are prefetched
+   */
+  async function preload(mutations: FinancialMutation[]) {
+    await nextTick(); // Wait for DOM/reactivity updates, if needed
+    const promises: Promise<void>[] = [];
+    for (const mutation of mutations) {
+      if (!mutation) continue;
+      // useMutationDetails expects Refs (type, id)
+      const { fetchMutation } = useMutationDetails(ref(mutation.type), ref(mutation.id));
+      promises.push(fetchMutation());
+    }
+    await Promise.all(promises);
+  }
+
+  return { preload };
+}

--- a/apps/dashboard/src/modules/user/views/UserLandingView.vue
+++ b/apps/dashboard/src/modules/user/views/UserLandingView.vue
@@ -10,7 +10,7 @@
         :header="t('components.mutations.recent')"
         router-link="transactions"
       >
-        <MutationsBalance :get-mutations="getUserMutations" :paginator="false" :rows-amount="6" />
+        <MutationsBalance :get-mutations="getUserMutations" :paginator="false" preload :rows-amount="6" />
       </CardComponent>
     </div>
   </PageContainer>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

So the whole reason I refactored the mutation modal was to do educated prefetching.

Old:
![Recording 2025-06-26 at 11 45 02](https://github.com/user-attachments/assets/343db945-bb5b-4ead-92d3-2cf57d12414e)

New:
![Recording 2025-06-26 at 12 01 41](https://github.com/user-attachments/assets/3fc2c1a8-c4c8-4364-aa84-e39aa4c8714f)

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- New feature _(non-breaking change which adds functionality)_
