### PR TITLE
fix: do not pre-fill balance field with 0

### DIFF
--- a/apps/dashboard/src/modules/user/components/forms/BalanceTopupForm.vue
+++ b/apps/dashboard/src/modules/user/components/forms/BalanceTopupForm.vue
@@ -6,7 +6,7 @@
         id="amount"
         column
         v-bind="form.model.amount.attr.value"
-        :errors="form.context.errors.value.amount"
+        :errors="(form.context.meta.value.touched && form.context.errors.value.amount) as string"
         :label="t('modules.user.balance.increaseAmount')"
         type="currency"
         :value="form.model.amount.value.value"

--- a/apps/dashboard/src/utils/validation-schema.ts
+++ b/apps/dashboard/src/utils/validation-schema.ts
@@ -231,7 +231,6 @@ export const topupSchema = yup.object({
   amount: yup
     .number()
     .required()
-    .default(0)
     .test('is-min10-or-balance', 'Top up should be more than €10 or settle debt exactly.', function (value) {
       const balance = this.parent.balance;
       return value >= 10 || Math.round(value * -100) === balance;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
When loading the page, the balance field is null, instead of 0. This means you can start typing right away, instead of having to actually remove the 0,00 that is there by default. very ergonomic very nice

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
