### PR TITLE
fix: message when cannot go into debt

### DIFF
--- a/apps/point-of-sale/src/components/Cart/CartActionsComponent.vue
+++ b/apps/point-of-sale/src/components/Cart/CartActionsComponent.vue
@@ -104,7 +104,6 @@ const finalizeCheckout = async () => {
     return;
   }
 
-
   stopCheckout();
   if (sound.value) {
     sound.value = new Audio('sounds/rct-cash.wav');
@@ -123,7 +122,6 @@ const checkout = () => {
     showDebtWarning.value = true;
     return;
   }
-
 
   if (borrelMode.value) {
     emit('selectCreator');

--- a/apps/point-of-sale/src/components/Cart/CartActionsComponent.vue
+++ b/apps/point-of-sale/src/components/Cart/CartActionsComponent.vue
@@ -11,9 +11,9 @@
     }"
     @click="resetDialog"
   >
-    <Message :closable="false" :icon="undefined" severity="warn">
+    <Message :icon="undefined" severity="warn">
       You cannot checkout as you are a user that cannot go into debt! <br />
-      Please remove items before you can continue.
+      Please remove items or top up before you can continue.
     </Message>
   </Dialog>
   <div class="flex justify-between w-full">
@@ -98,7 +98,12 @@ watch(cartItems, () => {
 });
 
 const finalizeCheckout = async () => {
-  if (unallowedUserInDebt.value) return stopCheckout();
+  if (unallowedUserInDebt.value) {
+    stopCheckout();
+    showDebtWarning.value = true;
+    return;
+  }
+
 
   stopCheckout();
   if (sound.value) {
@@ -113,7 +118,12 @@ const finalizeCheckout = async () => {
 };
 const checkout = () => {
   if (!enabled.value) return;
-  if (unallowedUserInDebt.value) return stopCheckout();
+  if (unallowedUserInDebt.value) {
+    stopCheckout();
+    showDebtWarning.value = true;
+    return;
+  }
+
 
   if (borrelMode.value) {
     emit('selectCreator');


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
A better message instead of nothing when trying to checkout on an account that cannot do this. 
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
<img width="626" height="260" alt="image" src="https://github.com/user-attachments/assets/c6b56ae8-848c-4208-bdfb-3b3ef712a3c7" />
The following message appears, which would also already appear when adding too many items to cause go into debt, or when selecting a different account to check out on. But for clarity also when clicking the checkout button. (checkout button was not made disabled cause then the cause would to be clear). Especially useful for accounts that were already fully in debt.

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_
