### PR TITLE
Refetch buyer when setting in cart store

### DIFF
--- a/apps/point-of-sale/src/stores/cart.store.ts
+++ b/apps/point-of-sale/src/stores/cart.store.ts
@@ -56,13 +56,18 @@ export const useCartStore = defineStore('cart', {
       this.lockedIn = lockedIn;
     },
     async setBuyer(buyer: UserResponse | null) {
-      this.buyer = buyer;
-      if (buyer) {
-        const response = await apiService.balance.getBalanceId(buyer.id).catch((this.buyerBalance = null));
-        this.buyerBalance = response.data.amount;
-      } else {
+      if (!buyer) {
+        this.buyer = null;
         this.buyerBalance = null;
+        return;
       }
+
+      // Refetch the data to ensure we have the latest data.
+      return apiService.user.getIndividualUser(buyer.id).then(async (res) => {
+        this.buyer = res.data;
+        this.buyerBalance = await apiService.balance.getBalanceId(buyer.id).then((res) => res.data.amount);
+        return this.buyer;
+      });
     },
     setCreatedBy(createdBy: BaseUserResponse) {
       this.createdBy = createdBy;


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the title above. -->

# Description

Some bugs turn out to be caused by old or partial user data (i.e. no GEWIS id). This also happens if we force a BaseUserResponse as a buyer. Refetching the user seems to be the easiest solution

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_
