### PR TITLE
feat(dashboard): show indication for edited transactions

### DIFF
--- a/apps/dashboard/src/components/mutations/MutationsBalance.vue
+++ b/apps/dashboard/src/components/mutations/MutationsBalance.vue
@@ -13,17 +13,41 @@
         <Skeleton class="h-1rem my-1 surface-300 w-6" />
       </template>
       <template v-else #body="mutation">
-        <span class="hidden sm:block">{{
-          mutation.data.moment.toLocaleDateString(locale, {
-            dateStyle: 'full',
-          })
-        }}</span>
-        <span class="sm:hidden whitespace-nowrap"
-          >{{
-            mutation.data.moment.toLocaleDateString('nl-NL', {
+        <span class="hidden sm:block">
+          {{
+            mutation.data.moment.toLocaleDateString(locale, {
+              dateStyle: 'full',
+            })
+          }}
+          <i
+            v-if="mutation.data.editedAt !== undefined"
+            v-tooltip="
+              t('components.mutations.editedOn', {
+                date: mutation.data.editedAt.toLocaleDateString(locale, {
+                  dateStyle: 'short',
+                }),
+              })
+            "
+            class="pi pi-pencil ml-2"
+          />
+        </span>
+        <span class="sm:hidden whitespace-nowrap">
+          {{
+            mutation.data.moment.toLocaleDateString(locale, {
               dateStyle: 'short',
             })
           }}
+          <i
+            v-if="mutation.data.editedAt !== undefined"
+            v-tooltip="
+              t('components.mutations.editedOn', {
+                date: mutation.data.editedAt.toLocaleDateString(locale, {
+                  dateStyle: 'short',
+                }),
+              })
+            "
+            class="pi pi-pencil ml-2"
+          />
         </span>
       </template>
     </Column>

--- a/apps/dashboard/src/components/mutations/mutationmodal/ModalDetailTransaction.vue
+++ b/apps/dashboard/src/components/mutations/mutationmodal/ModalDetailTransaction.vue
@@ -7,6 +7,16 @@
           timeStyle: 'short',
         })
       }}
+      <small v-if="transactionInfo.updatedAt !== transactionInfo.createdAt" class="ml-2 text-sm text-gray-500">
+        {{
+          t('components.mutations.editedOn', {
+            date: new Date(transactionInfo.updatedAt!).toLocaleString('nl-NL', {
+              dateStyle: 'short',
+              timeStyle: 'short',
+            }),
+          })
+        }}
+      </small>
     </span>
     <span>
       <UserLink :new-tab="true" :user="transactionInfo.from" />

--- a/apps/dashboard/src/locales/en/components/mutations.json
+++ b/apps/dashboard/src/locales/en/components/mutations.json
@@ -9,6 +9,7 @@
       "createdBy": "Created by",
       "By": "By",
       "createdFor": "Created for",
+      "editedOn": "Edited on {date}",
       "amount": "Amount",
       "pos": "Point of sale",
       "you": "You",

--- a/apps/dashboard/src/locales/nl/components/mutations.json
+++ b/apps/dashboard/src/locales/nl/components/mutations.json
@@ -9,6 +9,7 @@
       "createdBy": "Aangemaakt door",
       "By": "Door",
       "createdFor": "Aangemaakt voor",
+      "editedOn": "Bewerkt op {date}",
       "amount": "Bedrag",
       "pos": "Verkooppunt",
       "you": "Jij",

--- a/apps/dashboard/src/locales/pl/components/mutations.json
+++ b/apps/dashboard/src/locales/pl/components/mutations.json
@@ -9,6 +9,7 @@
       "createdBy": "Utworzone przez",
       "By": "Przez",
       "createdFor": "Utworzone dla",
+      "editedOn": "Edytowano dnia {date}",
       "amount": "Kwota",
       "pos": "Punkt sprzedaży",
       "you": "Ty",

--- a/apps/dashboard/src/utils/mutationUtils.ts
+++ b/apps/dashboard/src/utils/mutationUtils.ts
@@ -30,6 +30,7 @@ export interface FinancialMutation {
   id: number;
   pos?: string;
   createdBy?: BaseUserResponse | undefined;
+  editedAt?: Date | undefined;
 }
 
 export function parseTransaction(transaction: BaseTransactionResponse): FinancialMutation {
@@ -38,10 +39,11 @@ export function parseTransaction(transaction: BaseTransactionResponse): Financia
     to: undefined,
     from: transaction.from,
     type: FinancialMutationType.TRANSACTION,
-    moment: new Date(transaction.updatedAt!),
+    moment: new Date(transaction.createdAt!),
     id: transaction.id,
     pos: transaction.pointOfSale.name,
     createdBy: transaction.createdBy,
+    editedAt: transaction.updatedAt !== transaction.createdAt ? new Date(transaction.updatedAt!) : undefined,
   };
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Since we have implemented the functionality to edit transactions, it should also be made clear to users when one of their transactions has been edited.

Pencil icon in `MutationsBalance` component:
<img width="949" height="404" alt="image" src="https://github.com/user-attachments/assets/54cf5f78-d2bb-401a-afcf-ee134923fe29" />

Edited on annotation in transaction details:
<img width="541" height="350" alt="image" src="https://github.com/user-attachments/assets/0e198e8d-b303-4fdf-bc93-89567b81d989" />


## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
#649 

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- New feature _(non-breaking change which adds functionality)_
