### PR TITLE
feat(pos): Improve IsOfAge indication

### DIFF
--- a/apps/point-of-sale/src/components/Cart/CartComponent.vue
+++ b/apps/point-of-sale/src/components/Cart/CartComponent.vue
@@ -14,6 +14,10 @@
       >
         <i class="text-4xl" :class="lockIcon" />
       </Button>
+      <span v-if="!isOfAge()" class="flex items-center justify-end pt-1">
+        <i class="pi pi-info-circle pr-2" />
+        This user is underage.
+      </span>
     </div>
     <div v-if="!shouldShowTransactions || !showHistory" class="flex-col flex-grow-1 gap-2 mt-4 overflow-y-auto">
       <div v-for="item in cartItems" :key="item.product.id">
@@ -105,6 +109,10 @@ const displayName = () => {
   } else {
     return `${current.value?.firstName} ${current.value?.lastName}`;
   }
+};
+
+const isOfAge = () => {
+  return current.value?.ofAge ?? true;
 };
 
 const lockUser = () => {

--- a/apps/point-of-sale/src/components/UserSearch/UserSearchRowComponent.vue
+++ b/apps/point-of-sale/src/components/UserSearch/UserSearchRowComponent.vue
@@ -1,11 +1,11 @@
 <template>
   <div
     class="rounded-xl flex items-center font-semibold text-lg my-1 md:my-3 py-3 shadow-sm text-center pl-[75px] mr-[30px] text-white cursor-pointer user-row"
-    :class="{ 'opacity-35 cursor-not-allowed': !active }"
+    :class="{ 'opacity-35 cursor-not-allowed': !active, 'not-of-age': shouldShowAge() }"
     @click="selectUser"
   >
+    <i v-if="shouldShowAge()" class="pi pi-user-minus pr-2" />
     {{ displayName() }}
-    <i v-if="shouldShowAge()" class="pi pi-user-minus" />
   </div>
 </template>
 
@@ -57,5 +57,9 @@ const active = canUse;
 <style scoped lang="scss">
 .user-row {
   background-color: color-mix(in srgb, var(--p-primary-color) 85%, gray);
+}
+
+.not-of-age {
+  background-color: color-mix(in srgb, var(--p-primary-color) 50%, black);
 }
 </style>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Makes it clearer whether a user is underage when selecting them in the POS.
### Before change
<img width="354" height="75" alt="image" src="https://github.com/user-attachments/assets/5bd6da05-6e4c-42e0-9421-f7be277222f6" />

### After change
Regular POS:
<img width="291" height="72" alt="image" src="https://github.com/user-attachments/assets/6cbc2ad6-0397-43f2-99b7-a6678925131c" />
Borrelmodus:
<img width="354" height="75" alt="image" src="https://github.com/user-attachments/assets/2a74e7ed-9cec-453c-899c-946a627f8cb7" />

Also adds a small indication under the selected user:
<img width="273" height="136" alt="image" src="https://github.com/user-attachments/assets/c7c52e04-37bd-46b1-a6a8-5ee9f7654dc5" />

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
#658 

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- New feature _(non-breaking change which adds functionality)_