### PR TITLE
fix: revert date format for short dates

### DIFF
--- a/apps/dashboard/src/components/mutations/MutationsBalance.vue
+++ b/apps/dashboard/src/components/mutations/MutationsBalance.vue
@@ -23,7 +23,7 @@
             v-if="mutation.data.editedAt !== undefined"
             v-tooltip="
               t('components.mutations.editedOn', {
-                date: mutation.data.editedAt.toLocaleDateString(locale, {
+                date: mutation.data.editedAt.toLocaleDateString('nl-NL', {
                   dateStyle: 'short',
                 }),
               })
@@ -33,7 +33,7 @@
         </span>
         <span class="sm:hidden whitespace-nowrap">
           {{
-            mutation.data.moment.toLocaleDateString(locale, {
+            mutation.data.moment.toLocaleDateString('nl-NL', {
               dateStyle: 'short',
             })
           }}
@@ -41,7 +41,7 @@
             v-if="mutation.data.editedAt !== undefined"
             v-tooltip="
               t('components.mutations.editedOn', {
-                date: mutation.data.editedAt.toLocaleDateString(locale, {
+                date: mutation.data.editedAt.toLocaleDateString('nl-NL', {
                   dateStyle: 'short',
                 }),
               })


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Revert the date formatting for short dates, as 'en' defaults to Americans. And Americans have decided to flip the months and days. This is fine for 10/31/2025, but 05/12/2025 can become very confusing. I propose to use the default used in Europe/NL, which is day-month-year, therefore the locale should be 'nl-NL'.

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
