### PR TITLE
fix(dash): add dropdown indication for financial in navbar

### DIFF
--- a/apps/dashboard/src/components/NavbarMenu.vue
+++ b/apps/dashboard/src/components/NavbarMenu.vue
@@ -39,7 +39,7 @@
               <div class="flex items-center">
                 <span v-if="item.icon" :class="item.icon + (item.label ? ' ml-2' : '')" />
                 <Badge v-if="item.notifications" class="ml-2" severity="secondary" :value="item.notifications" />
-                <span v-else-if="hasSubmenu" class="ml-2 pi pi-angle-down pi-fw" />
+                <span v-if="hasSubmenu" class="ml-2 pi pi-angle-down pi-fw" />
               </div>
             </template>
           </div>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
If a navbar item had notifications, the `pi-angle-down` icon was not displayed, which made it unclear that the navbar item is a dropdown.

Before:
<img width="608" height="96" alt="image" src="https://github.com/user-attachments/assets/80578bec-a66c-4a12-b4de-a6701658d975" />

After:
<img width="608" height="96" alt="image" src="https://github.com/user-attachments/assets/1b73218a-211a-4344-9331-cb97bb7263e9" />

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_
