### PR TITLE
feat: Add admin login for maintenance mode

### DIFF
--- a/apps/dashboard/src/components/MaintenanceModeOverlay.vue
+++ b/apps/dashboard/src/components/MaintenanceModeOverlay.vue
@@ -7,20 +7,41 @@
       <img alt="logo" class="block mx-auto mb-5 max-h-[25rem]" src="@/assets/img/bier_grayscale.png" />
       <div class="font-bold text-3xl text-center">{{ t('common.maintenanceMode.title') }}</div>
       <div class="text-2xl text-center">{{ t('common.maintenanceMode.subtitle') }}</div>
+      <div class="text-center mt-5">
+        <a v-if="!showLogin" class="block text-center underline cursor-pointer" @click="toggleShowLogin">
+          {{ t('common.maintenanceMode.adminLogin') }}
+        </a>
+        <div v-else>
+          <Card>
+            <template #content>
+              <AuthLocalForm :form="form" />
+            </template>
+          </Card>
+          <a class="block text-center underline cursor-pointer mt-2" @click="toggleShowLogin">
+            {{ t('common.maintenanceMode.cancelLogin') }}
+          </a>
+        </div>
+      </div>
     </main>
   </div>
 </template>
 
 <script setup lang="ts">
 import { useAuthStore } from '@sudosos/sudosos-frontend-common';
-import { watch } from 'vue';
+import { ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import { useIsMaintenance } from '@/composables/isMaintenance';
+import AuthLocalForm from '@/modules/auth/components/forms/AuthLocalForm.vue';
+import { schemaToForm } from '@/utils/formUtils';
+import { localAuthForm } from '@/utils/validation-schema';
 
 const { t } = useI18n();
 const router = useRouter();
 const { isMaintenance, canOverride } = useIsMaintenance();
+const form = schemaToForm(localAuthForm);
+
+const showLogin = ref(false);
 
 watch(
   () => isMaintenance.value,
@@ -32,6 +53,13 @@ watch(
     }
   },
 );
+
+const toggleShowLogin = () => {
+  showLogin.value = !showLogin.value;
+  if (!showLogin.value) {
+    form.context.resetForm();
+  }
+};
 </script>
 
 <style scoped lang="scss"></style>

--- a/apps/dashboard/src/components/MaintenanceModeOverlay.vue
+++ b/apps/dashboard/src/components/MaintenanceModeOverlay.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="isMaintenance && !canOverride"
-    class="absolute top-0 left-0 w-full h-full flex text-white justify-center items-center z-10 bg-red-700"
+    class="fixed top-0 left-0 w-full h-full flex text-white justify-center items-center z-10 bg-red-700"
   >
     <main>
       <img alt="logo" class="block mx-auto mb-5 max-h-[25rem]" src="@/assets/img/bier_grayscale.png" />

--- a/apps/dashboard/src/locales/en/common/common.json
+++ b/apps/dashboard/src/locales/en/common/common.json
@@ -243,7 +243,9 @@
     "maintenanceMode": {
       "title": "SudoSOS is under maintenance.",
       "subtitle": "Please try again later...",
-      "footer": "MAINTENANCE ENABLED"
+      "footer": "MAINTENANCE ENABLED",
+      "adminLogin": "Admin login",
+      "cancelLogin": "Cancel login"
     }
   }
 }

--- a/apps/dashboard/src/locales/nl/common/common.json
+++ b/apps/dashboard/src/locales/nl/common/common.json
@@ -241,7 +241,9 @@
     "maintenanceMode": {
       "title": "SudoSOS is onder onderhoud.",
       "subtitle": "Probeer het later nog eens...",
-      "footer": "ONDERHOUD GEACTIVEERD"
+      "footer": "ONDERHOUD GEACTIVEERD",
+      "adminLogin": "Inloggen beheerder",
+      "cancelLogin": "Inloggen annuleren"
     }
   }
 }

--- a/apps/dashboard/src/locales/pl/common/common.json
+++ b/apps/dashboard/src/locales/pl/common/common.json
@@ -242,7 +242,9 @@
     "maintenanceMode": {
       "title": "SudoSOS jest w trybie konserwacji.",
       "subtitle": "Spróbuj ponownie później...",
-      "footer": "TRYB KONSERWACJI WŁĄCZONY"
+      "footer": "TRYB KONSERWACJI WŁĄCZONY",
+      "adminLogin": "Logowanie administratora",
+      "cancelLogin": "Anuluj logowanie"
     }
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Adds the ability for admins to log in while maintenance mode is enabled. This functionality is available to all users with a role that includes the maintenance override permission.

Also changes the positioning of the overlay from `absolute` to `fixed`, which makes it so that the overlay always covers the entire webpage.

#### Screenshots
<img width="800" alt="image" src="https://github.com/user-attachments/assets/502d815d-b4b2-4ed8-be69-8446999d1f5f" />

<img width="800" alt="image" src="https://github.com/user-attachments/assets/f38187f9-cce9-46de-b78a-2222a4e69544" />


## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- New feature _(non-breaking change which adds functionality)_
