### PR TITLE
fix: footer styling on small screens

### DIFF
--- a/apps/dashboard/src/components/footer/FooterBar.vue
+++ b/apps/dashboard/src/components/footer/FooterBar.vue
@@ -47,7 +47,7 @@ const { isMaintenance, canOverride } = useIsMaintenance();
 footer {
   width: 100%;
   padding: 0 1rem;
-  height: 60px;
+  height: fit-content;
   line-height: 60px;
   background-color: var(--p-content-background);
 }

--- a/apps/dashboard/src/components/footer/FooterTermsOfServiceModal.vue
+++ b/apps/dashboard/src/components/footer/FooterTermsOfServiceModal.vue
@@ -30,6 +30,7 @@ const visible = ref(false);
 </script>
 <style>
 .tosLink {
+  display: inline-block;
   color: var(--p-primary-color);
 }
 


### PR DESCRIPTION
# Description

The footer weirdly split the tos link when it didn't line anymore. The coloring also didn't extend beyond the first line, even when the content took up more than one.
It now correctly splits the elements when the space gets to small and the coloring takes up the appropriate amount of lines.

**Previously:**
<img width="1079" height="381" alt="image" src="https://github.com/user-attachments/assets/4641aac3-1172-4a90-b2e4-3ffc91efa302" />
**Fixed:**
<img width="243" height="103" alt="image" src="https://github.com/user-attachments/assets/466acb80-edc3-4117-990d-886954e1d0c0" />

## Related issues/external references
#682 

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_

