### PR TITLE
feat: Wrapped focus overlay

### DIFF
--- a/apps/dashboard/src/components/wrapped/0_WelcomeCard.vue
+++ b/apps/dashboard/src/components/wrapped/0_WelcomeCard.vue
@@ -1,6 +1,13 @@
 <!-- eslint-disable @intlify/vue-i18n/no-raw-text -->
 <template>
-  <div class="card-root" :class="{ active }">
+  <div ref="rootRef" class="card-root relative" :class="{ active }">
+    <div
+      class="focus-overlay bg-[#b40000] z-10 text-white absolute inset-0 flex flex-col items-center justify-center p-1 text-center"
+      :class="{ visible: overlayVisible }"
+    >
+      <h1 class="font-bold text-xl">Make sure the window is focused</h1>
+      <h2 class="italic pt-4">Swipe down until this text disappears.</h2>
+    </div>
     <div class="bg bier-bg"></div>
 
     <div class="content text-white">
@@ -23,11 +30,104 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, toRef } from 'vue';
+import { defineProps, toRef, ref, onMounted, onUnmounted, watch } from 'vue';
 const props = defineProps<{ active?: boolean; firstName?: string; showArrows?: boolean }>();
 const active = toRef(props, 'active');
 const firstName = toRef(props, 'firstName');
 const showArrows = toRef(props, 'showArrows');
+
+const rootRef = ref<HTMLElement | null>(null);
+let observer: IntersectionObserver | null = null;
+let overlayTimeout: number | null = null;
+let started = false;
+const overlayVisible = ref(!showArrows.value);
+let pendingWatcher: (() => void) | null = null;
+
+function scheduleHide() {
+  if (overlayTimeout != null) {
+    clearTimeout(overlayTimeout);
+    overlayTimeout = null;
+  }
+  overlayTimeout = window.setTimeout(() => {
+    overlayVisible.value = false;
+    overlayTimeout = null;
+  }, 1);
+  // once scheduled, disconnect observer and stop watching active
+  if (observer) {
+    observer.disconnect();
+    observer = null;
+  }
+  if (pendingWatcher) {
+    pendingWatcher();
+    pendingWatcher = null;
+  }
+}
+
+function tryStartAnimation() {
+  if (started) return;
+  started = true;
+
+  // If screen isn't narrow, don't show the overlay — disconnect observer and exit
+  if (showArrows.value) {
+    overlayVisible.value = false;
+    if (observer) {
+      observer.disconnect();
+      observer = null;
+    }
+    return;
+  }
+
+  // ensure overlay is shown when animation starts
+  overlayVisible.value = true;
+
+  // If the card is active right now, schedule the hide immediately.
+  // Otherwise, wait until `active` becomes true.
+  if (active.value) {
+    scheduleHide();
+  } else {
+    // watch for active -> true, then schedule hide; store the stop handle to clean up later
+    pendingWatcher = watch(active, (v) => {
+      if (v) scheduleHide();
+    });
+  }
+}
+
+onMounted(() => {
+  if (!rootRef.value) return;
+  observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        // threshold 1.0 ensures it's fully visible
+        if (entry.isIntersecting && entry.intersectionRatio >= 1) {
+          tryStartAnimation();
+        }
+      }
+    },
+    { threshold: [1.0] },
+  );
+
+  observer.observe(rootRef.value);
+
+  // If the card is already fully visible on mount, attempt to start the animation
+  const rect = rootRef.value.getBoundingClientRect();
+  const fullyVisible = rect.top >= 0 && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight);
+  if (fullyVisible) tryStartAnimation();
+});
+
+onUnmounted(() => {
+  if (observer) {
+    observer.disconnect();
+    observer = null;
+  }
+  if (overlayTimeout != null) {
+    clearTimeout(overlayTimeout);
+    overlayTimeout = null;
+  }
+  if (pendingWatcher) {
+    pendingWatcher();
+    pendingWatcher = null;
+  }
+});
 </script>
 
 <style scoped>
@@ -36,5 +136,14 @@ const showArrows = toRef(props, 'showArrows');
   background-size: 90%;
   opacity: 0.4;
   transform: translate(-5%, 0) rotate(-12deg);
+}
+
+.focus-overlay {
+  opacity: 0;
+  transition: opacity 1ms ease-in-out;
+}
+
+.focus-overlay.visible {
+  opacity: 1;
 }
 </style>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Adds an overlay to the first Wrapped card that only appears when the window is not in focus.

As soon as the window is focussed, the overlay disappears and Wrapped is shown as normal.

Nothing changes for desktop view.

Has been tested on mobile on Android in Firefox and Chrome.

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- New feature _(non-breaking change which adds functionality)_