### PR TITLE
style(dashboard): Transition speed for PrimeVue components

### DIFF
--- a/apps/dashboard/src/assets/theme-overrides.css
+++ b/apps/dashboard/src/assets/theme-overrides.css
@@ -12,3 +12,7 @@
 .p-tablist-active-bar {
   background-color: var(--p-secondary-color) !important;
 }
+
+:root {
+  --p-transition-duration: 0;
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
The transition speed for PrimeVue components was set to 0.2s by default. This did not match the transition speed for other components (like the background).

The transition duration for PrimeVue components has been changed to 0, to match all other components' transition speeds.

### Before change
![Screencast from 2025-12-20 20-03-25](https://github.com/user-attachments/assets/67819ef4-eb31-48ca-83c5-5785e4e3ae64)

### After change
![Screencast from 2025-12-20 20-08-58](https://github.com/user-attachments/assets/55a4f841-b752-4cc6-8ec9-345d502def82)

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Style _(Change that do not affect the functionality of the code)_
