### PR TITLE
fix: icon for logout

### DIFF
--- a/apps/point-of-sale/src/components/Cart/CartActionsComponent.vue
+++ b/apps/point-of-sale/src/components/Cart/CartActionsComponent.vue
@@ -30,7 +30,7 @@
         class="p-3 text-2xl text-white flex items-center justify-center w-16 h-16"
         @click="logout"
       >
-        <i class="pi pi-times" style="font-size: 2rem" />
+        <i class="pi pi-sign-out" style="font-size: 2rem" />
       </Button>
     </div>
   </div>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
When a POS is not in `borrelMode`, a logout button is shown. However, the icon may suggest it is for clearing the selected products rather than logging out.

With this change, the icon is updated to signal that the action will log the user out.


## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_