### PR TITLE
fix: disable buyer select button after press

### DIFF
--- a/apps/point-of-sale/src/components/BuyerSelect/BuyerSelectButtonComponent.vue
+++ b/apps/point-of-sale/src/components/BuyerSelect/BuyerSelectButtonComponent.vue
@@ -2,10 +2,12 @@
   <Button
     v-if="!isGhost && associate"
     class="text-lg px-4 py-4 select-user"
+    :disabled="props.isDisabled"
     :outlined="associate.type !== 'owner'"
     @click="select()"
   >
-    <span>
+    <ProgressSpinner v-if="props.isLoading" stroke-width="4" style="width: 30px; height: 30px" />
+    <span v-else>
       {{ associate.firstName }}
       <span v-if="associate.nickname" class="italic"> "{{ associate.nickname }}"</span>
       {{ associate.lastName }}
@@ -16,6 +18,7 @@
 
 <script setup lang="ts">
 import Button from 'primevue/button';
+import ProgressSpinner from 'primevue/progressspinner';
 import { useCartStore } from '@/stores/cart.store';
 import { PointOfSaleAssociate } from '@/stores/pos.store';
 
@@ -25,19 +28,25 @@ const props = withDefaults(
   defineProps<{
     associate: PointOfSaleAssociate | null;
     isGhost?: boolean;
+    isDisabled?: boolean;
+    isLoading?: boolean;
   }>(),
   {
     associate: null,
     isGhost: false,
+    isDisabled: false,
+    isLoading: false,
   },
 );
 
 const emit = defineEmits<{
   cancelSelectCreator: [];
+  buttonClicked: [number];
 }>();
 
 const select = async () => {
   if (!props.associate) return;
+  emit('buttonClicked', props.associate.id);
   cartStore.setCreatedBy(props.associate);
   await cartStore.checkout();
   emit('cancelSelectCreator');

--- a/apps/point-of-sale/src/components/BuyerSelect/BuyerSelectionComponent.vue
+++ b/apps/point-of-sale/src/components/BuyerSelect/BuyerSelectionComponent.vue
@@ -13,7 +13,10 @@
         v-for="item in sortedAssociatesWithGaps"
         :key="item.key"
         :associate="item.associate"
+        :is-disabled="isDisabled"
         :is-ghost="item.isGhost"
+        :is-loading="item.associate ? loadingAssociateId === item.associate.id : false"
+        @button-clicked="handleButtonClick"
         @cancel-select-creator="cancelSelect()"
       />
     </div>
@@ -21,7 +24,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import Button from 'primevue/button';
 import { PointOfSaleAssociate, usePointOfSaleStore } from '@/stores/pos.store';
 import BuyerSelectButtonComponent from '@/components/BuyerSelect/BuyerSelectButtonComponent.vue';
@@ -29,6 +32,13 @@ import BuyerSelectButtonComponent from '@/components/BuyerSelect/BuyerSelectButt
 const emit = defineEmits(['cancelSelectCreator']);
 
 const posStore = usePointOfSaleStore();
+const isDisabled = ref(false);
+const loadingAssociateId = ref<number | null>(null);
+
+const handleButtonClick = (associateId: number) => {
+  isDisabled.value = true;
+  loadingAssociateId.value = associateId;
+};
 const currentPos = posStore.getPos;
 const posAssociates = computed<PointOfSaleAssociate[] | null>(() => posStore.getPointOfSaleAssociates);
 const organName = computed(() => posStore.getPos?.owner?.firstName);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
The same transaction would be made multiple times if the buyer button was pressed multiple times before the first transaction was completed.

This is fixed by disabling all buyer buttons after one is pressed. The text on the button that has been pressed is replaced with a spinner to indicate that the system is in fact doing something.

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_
