### PR TITLE
fix: no timer on authenticated POS

### DIFF
--- a/apps/point-of-sale/src/stores/settings.store.ts
+++ b/apps/point-of-sale/src/stores/settings.store.ts
@@ -35,7 +35,7 @@ export const useSettingStore = defineStore('setting', {
       }
     },
     showTimers(): boolean {
-      return location.hostname !== 'localhost';
+      return location.hostname !== 'localhost' && this.isAuthenticatedPos;
     },
   },
   actions: {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Makes it so the logout timer is not displayed on a POS that does not need authentication.

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_
