### PR TITLE
Hide alcohol warning if not loaded

### DIFF
--- a/apps/point-of-sale/src/components/PointOfSaleDisplay/PointOfSaleDisplayComponent.vue
+++ b/apps/point-of-sale/src/components/PointOfSaleDisplay/PointOfSaleDisplayComponent.vue
@@ -37,10 +37,7 @@
       </div>
     </div>
     <div class="m-2 mr-6">
-      <Message
-        v-if="isCategoryAlcoholic && !useSettingStore().isAlcoholTime && pointOfSale?.useAuthentication"
-        severity="warn"
-      >
+      <Message v-if="shouldShowAlcoholWarning" severity="warn">
         Please note that today, alcoholic drinks are only allowed to be served after
         {{
           new Date(useSettingStore().alcoholTimeToday).toLocaleTimeString('nl-NL', {
@@ -93,6 +90,16 @@ const productCount = computed(() => {
     });
   });
   return ids.size;
+});
+
+const settingStore = useSettingStore();
+const shouldShowAlcoholWarning = computed(() => {
+  return (
+    settingStore.loaded &&
+    isCategoryAlcoholic.value &&
+    !settingStore.isAlcoholTime &&
+    props.pointOfSale?.useAuthentication
+  );
 });
 
 const shouldShowAllCategory = computed(() => {

--- a/apps/point-of-sale/src/stores/settings.store.ts
+++ b/apps/point-of-sale/src/stores/settings.store.ts
@@ -4,7 +4,8 @@ import { usePointOfSaleStore } from '@/stores/pos.store';
 
 export const useSettingStore = defineStore('setting', {
   state: () => ({
-    alcoholTimeToday: Date.now() + 24 * 60 * 60 * 1000, // Should always be recalculated
+    alcoholTimeToday: Date.now() + 24 * 60 * 60 * 1000,
+    loaded: false,
   }),
   getters: {
     isAuthenticatedPos(): boolean {
@@ -54,6 +55,7 @@ export const useSettingStore = defineStore('setting', {
       let alcTime = '16:30';
 
       if (alcTimeRes.ok) {
+        this.loaded = true;
         const alcTimeResText = await alcTimeRes.text();
 
         // If time matches XX:XX regex


### PR DESCRIPTION
In case that alochol time cannot be loaded it is hidden instead of showing current timestamp.