### PR TITLE
feat: fill email field for password reset

### DIFF
--- a/apps/dashboard/src/modules/auth/views/AuthResetView.vue
+++ b/apps/dashboard/src/modules/auth/views/AuthResetView.vue
@@ -49,6 +49,10 @@ onBeforeMount(() => {
     resetForm.context.setFieldValue('email', email);
     passwordResetMode.value = ResetMode.SetNew;
   }
+
+  if (email) {
+    requestForm.context.setFieldValue('email', email);
+  }
 });
 
 const backToLogin = () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Makes it so that if a user visits the reset password page with an `email` query parameter, through e.g: `https://sudosos.gewis.nl/passwordreset?email=user13%40example.com`, the email field on the reset password page is already filled with the users email address.

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- New feature _(non-breaking change which adds functionality)_
