### PR TITLE
fix(pos): remove close button from switch POS modal

### DIFF
--- a/apps/point-of-sale/src/components/SettingsIconComponent.vue
+++ b/apps/point-of-sale/src/components/SettingsIconComponent.vue
@@ -21,10 +21,6 @@
       />
 
       <div v-if="usersPointOfSales && usersPointOfSales.length > 0" class="flex gap-3 pt-4 justify-end">
-        <Button class="px-3 py-2" outlined @click="visible = false">
-          <i class="pi pi-times mr-2" />
-          Close
-        </Button>
         <Button class="px-3 py-2" @click="forceExit">
           <i class="pi pi-sign-out mr-2" />
           Force logout


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
There is already a close button at the top right of the modal.

This additional button causes inconsistencies with the other modals in the POS.

Before:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/9d63039a-4fbd-4c9e-9b24-533e09e80865" />

After:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/8e9685d9-c37e-4cb4-89ea-0a151c5d53f0" />

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_
