### PR TITLE
fix(dashboard): beta sync overlay spinner color

### DIFF
--- a/apps/dashboard/src/components/BetaSyncOverlay.vue
+++ b/apps/dashboard/src/components/BetaSyncOverlay.vue
@@ -4,7 +4,7 @@
     class="fixed top-0 left-0 w-full h-full flex text-white justify-center items-center z-[9999] bg-red bg-opacity-75"
   >
     <main class="flex flex-col items-center gap-4">
-      <ProgressSpinner />
+      <ProgressSpinner class="white-spinner" />
       <div class="font-bold text-xl text-center">{{ t('common.betaSync.redirecting') }}</div>
       <div class="text-lg text-center">{{ t('common.betaSync.message') }}</div>
     </main>
@@ -25,5 +25,11 @@ const { t } = useI18n();
 <style scoped lang="scss">
 .bg-red {
   background: var(--p-primary-color);
+}
+.white-spinner {
+  --p-progressspinner-color-one: white;
+  --p-progressspinner-color-two: white;
+  --p-progressspinner-color-three: white;
+  --p-progressspinner-color-four: white;
 }
 </style>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
The beta sync overaly background color is the primary color, which made it so that the spinner was not visible, since it is the same color.

The spinner is now white.

Before:
<img width="392" height="364" alt="image" src="https://github.com/user-attachments/assets/ee942a42-1b51-4b02-b153-af8fc2037000" />

After:
<img width="392" height="364" alt="image" src="https://github.com/user-attachments/assets/c4e1e85f-1eaa-4b30-b115-989afd0290d1" />


## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_
