### PR TITLE
Add authenticated websockets for reactive history in POS

### DIFF
--- a/apps/point-of-sale/src/components/Cart/CartComponent.vue
+++ b/apps/point-of-sale/src/components/Cart/CartComponent.vue
@@ -24,7 +24,11 @@
         <CartItemComponent :cart-product="item" />
       </div>
     </div>
-    <TransactionHistoryComponent v-else-if="shouldShowTransactions" :transactions="transactions" />
+    <TransactionHistoryComponent
+      v-else-if="shouldShowTransactions"
+      :open-transaction-id="openTransactionId"
+      :transactions="transactions"
+    />
     <div class="bg-white rounded-xl font-size-lg mt-3 px-3 py-2 shadow-sm">
       <div class="flex justify-between items-center w-full">
         <div class="font-semibold">Total</div>
@@ -62,8 +66,16 @@ const showHistory = ref(true);
 const { pointOfSale } = storeToRefs(posStore as StoreGeneric);
 const { lockedIn } = storeToRefs(cartStore as StoreGeneric);
 
-const { transactions, shouldShowTransactions, loadTransactions, displayName, isOfAge, lockUser, showLock } =
-  useCartTransactions(pointOfSale);
+const {
+  transactions,
+  openTransactionId,
+  shouldShowTransactions,
+  loadTransactions,
+  displayName,
+  isOfAge,
+  lockUser,
+  showLock,
+} = useCartTransactions(pointOfSale);
 
 const lockIcon = computed(() => {
   return cartStore.lockedIn ? 'pi pi-lock' : 'pi pi-unlock';

--- a/apps/point-of-sale/src/components/Cart/TransactionHistory/TransactionHistoryComponent.vue
+++ b/apps/point-of-sale/src/components/Cart/TransactionHistory/TransactionHistoryComponent.vue
@@ -17,7 +17,7 @@ more information when clicked. */
 
 <script setup lang="ts">
 import { BaseTransactionResponse } from '@sudosos/sudosos-client';
-import { Ref, ref } from 'vue';
+import { Ref, ref, watch } from 'vue';
 import TransactionHistoryRowComponent from '@/components/Cart/TransactionHistory/TransactionHistoryRowComponent.vue';
 
 const props = defineProps({
@@ -25,10 +25,21 @@ const props = defineProps({
     type: Object as () => BaseTransactionResponse[],
     required: true,
   },
+  openTransactionId: {
+    type: Number as () => number | null,
+    default: null,
+  },
 });
 
 // Which transaction to open. null means that it should open the top transaction.
 const openId: Ref<number | undefined | null> = ref(null);
+
+watch(
+  () => props.openTransactionId,
+  (id) => {
+    if (id != null) openId.value = id;
+  },
+);
 
 const shouldOpen = (transaction: BaseTransactionResponse) => {
   return transaction.id === openId.value || (openId.value === null && transaction.id === props.transactions[0]!.id);

--- a/apps/point-of-sale/src/components/Cart/TransactionHistory/TransactionHistoryRowComponent.vue
+++ b/apps/point-of-sale/src/components/Cart/TransactionHistory/TransactionHistoryRowComponent.vue
@@ -38,7 +38,7 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, onBeforeUnmount, onMounted, Ref, ref, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, Ref, ref, watch } from 'vue';
 import { BaseTransactionResponse, TransactionResponse } from '@sudosos/sudosos-client';
 import { formatDateFromString, formatTimeFromString, formatDineroObjectToString } from '@/utils/FormatUtils';
 import { userApiService } from '@/services/ApiService';
@@ -49,7 +49,7 @@ const settings = useSettingStore();
 
 const props = defineProps({
   transaction: {
-    type: Object as () => BaseTransactionResponse,
+    type: Object as () => BaseTransactionResponse | TransactionResponse,
     required: true,
   },
   open: {
@@ -112,7 +112,10 @@ async function leave(el: Element) {
 const toggleOpen = () => emit('update:open', props.transaction.id);
 const formattedDate = formatDateFromString(props.transaction.createdAt);
 const formattedTime = formatTimeFromString(props.transaction.createdAt);
-const formattedValue = formatDineroObjectToString(props.transaction.value, false);
+const transactionValue = computed(() =>
+  'value' in props.transaction ? props.transaction.value : props.transaction.totalPriceInclVat,
+);
+const formattedValue = computed(() => formatDineroObjectToString(transactionValue.value, false));
 const isCreatedByDifferent = props.transaction.createdBy?.id !== props.transaction.from.id || settings.isBorrelmode;
 </script>
 

--- a/apps/point-of-sale/src/utils/FormatUtils.ts
+++ b/apps/point-of-sale/src/utils/FormatUtils.ts
@@ -17,8 +17,9 @@ export function formatPrice(number: number) {
   return (number / 100).toFixed(2).replace('.', ',');
 }
 
-export function formatDineroObjectToString(dinero: DineroObjectResponse, includeCurrency = true) {
-  const base = (dinero.amount / 10 ** dinero.precision).toFixed(2).replace('.', ',');
+export function formatDineroObjectToString(dinero: DineroObjectResponse | undefined | null, includeCurrency = true) {
+  if (dinero == null || typeof dinero.amount !== 'number') return includeCurrency ? '€0,00' : '0,00';
+  const base = (dinero.amount / 10 ** (dinero.precision ?? 2)).toFixed(2).replace('.', ',');
   if (includeCurrency) return `€${base}`;
   return base;
 }

--- a/lib/common/src/index.ts
+++ b/lib/common/src/index.ts
@@ -16,6 +16,6 @@ export {
 export { fetchAllPages } from './helpers/PaginationHelper';
 export { addListenerOnDialogueOverlay } from './utils/dialogUtil';
 export { getRelation, isAllowed } from './utils/permissionUtil';
-export { setupWebSocket } from './services/webSocketService';
+export { setupWebSocket, type WebSocketSetupOptions } from './services/webSocketService';
 export { useWebSocketStore } from './stores/websocket.store';
 export { useWebSocketConnectionWatcher } from './mixins/useWebSocketConnectionWatcher';

--- a/lib/common/src/services/webSocketService.ts
+++ b/lib/common/src/services/webSocketService.ts
@@ -1,7 +1,12 @@
 import { io } from 'socket.io-client';
 import { useWebSocketStore } from '../stores/websocket.store';
 
-export const setupWebSocket = () => {
+export interface WebSocketSetupOptions {
+  token?: string | null;
+}
+
+export const setupWebSocket = (options?: WebSocketSetupOptions) => {
+  const token = options?.token;
   const socket = io({
     path: '/ws/socket.io',
     transports: ['websocket'],
@@ -9,6 +14,7 @@ export const setupWebSocket = () => {
     reconnectionDelay: 1000,
     reconnectionDelayMax: 5000,
     reconnectionAttempts: Infinity,
+    ...(token ? { auth: { token } } : {}),
   });
 
   const websocketStore = useWebSocketStore();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

Use POS token to subscribe to transaction updates, which is in turn used to update the cart history component.

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- New feature _(non-breaking change which adds functionality)_