### PR TITLE
fix: buyer select spinner color

### DIFF
--- a/apps/point-of-sale/src/components/BuyerSelect/BuyerSelectButtonComponent.vue
+++ b/apps/point-of-sale/src/components/BuyerSelect/BuyerSelectButtonComponent.vue
@@ -6,7 +6,7 @@
     :outlined="associate.type !== 'owner'"
     @click="select()"
   >
-    <ProgressSpinner v-if="props.isLoading" stroke-width="4" style="width: 30px; height: 30px" />
+    <ProgressSpinner v-if="props.isLoading" class="white-spinner" stroke-width="4" />
     <span v-else>
       {{ associate.firstName }}
       <span v-if="associate.nickname" class="italic"> "{{ associate.nickname }}"</span>
@@ -66,5 +66,14 @@ const select = async () => {
 .ghost-button {
   opacity: 0;
   pointer-events: none;
+}
+
+.white-spinner {
+  width: 30px;
+  height: 30px;
+  --p-progressspinner-color-one: white;
+  --p-progressspinner-color-two: white;
+  --p-progressspinner-color-three: white;
+  --p-progressspinner-color-four: white;
 }
 </style>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

The spinner that appears when a buyer has been selected, but no response from the backend has been received yet, was the same color as the background.

Old:
<img width="391" height="95" alt="image" src="https://github.com/user-attachments/assets/8b1a3dd6-03c8-4260-b758-7a045334351e" />

New:
<img width="391" height="95" alt="image" src="https://github.com/user-attachments/assets/080e991d-6f0d-49f8-84fb-1f95dc389cf5" />

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_