### PR TITLE
feat: show POS info when current POS is clicked

### DIFF
--- a/apps/point-of-sale/src/components/PosSwitchDisplay.vue
+++ b/apps/point-of-sale/src/components/PosSwitchDisplay.vue
@@ -34,12 +34,15 @@
       </div>
     </div>
   </div>
+  <PosTokenInfoModal v-model="showModal" />
 </template>
 
 <script setup lang="ts">
 import { PointOfSaleResponse } from '@sudosos/sudosos-client';
 import Button from 'primevue/button';
 import ProgressSpinner from 'primevue/progressspinner';
+import { ref } from 'vue';
+import PosTokenInfoModal from '@/components/PosTokenInfoModal.vue';
 
 interface Props {
   groupedPos: Record<string, PointOfSaleResponse[]>;
@@ -66,9 +69,15 @@ const emit = defineEmits<{
 }>();
 
 const handlePosClick = (pos: PointOfSaleResponse) => {
-  if (props.currentPosId === pos.id || props.switching) return;
+  if (props.switching) return;
+  if (props.currentPosId === pos.id) {
+    showModal.value = true;
+    return;
+  }
   emit('select', pos);
 };
+
+const showModal = ref(false);
 </script>
 
 <style scoped lang="scss">

--- a/apps/point-of-sale/src/components/PosSwitchDisplay.vue
+++ b/apps/point-of-sale/src/components/PosSwitchDisplay.vue
@@ -25,9 +25,12 @@
             :outlined="currentPosId !== pos.id"
             @click="handlePosClick(pos)"
           >
-            <div class="flex flex-col items-start">
-              <span class="font-semibold">{{ pos.name }}</span>
-              <span v-if="currentPosId === pos.id" class="text-sm opacity-75">(Current)</span>
+            <div class="flex items-center justify-between w-full">
+              <div class="flex flex-col items-start">
+                <span class="font-semibold">{{ pos.name }}</span>
+                <span v-if="currentPosId === pos.id" class="text-sm opacity-75">(Current)</span>
+              </div>
+              <i v-if="currentPosId === pos.id" class="pi pi-info-circle text-xl ml-2"></i>
             </div>
           </Button>
         </div>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Makes the `PosTokenInfoModal` visible when the currently selected POS is clicked in the `PosSwitchDisplay`. This will allow us to check the token info without having to log out.

![Screencast From 2026-02-16 15-21-41](https://github.com/user-attachments/assets/41f33e72-056d-4297-8f54-dd3cace42d5b)

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- New feature _(non-breaking change which adds functionality)_
