### PR TITLE
fix(rbac): reload page after add/delete permission actions

### DIFF
--- a/apps/dashboard/src/composables/useRBACUpdating.ts
+++ b/apps/dashboard/src/composables/useRBACUpdating.ts
@@ -93,17 +93,7 @@ export function useRBACUpdating(
     apiService.rbac
       .deletePermission(id, entity, action, relation)
       .then(() => {
-        const allRelations: ActionResponse[] = [];
-        form.context.values.currentPermission.actions.forEach((action) => {
-          action.relations.forEach((relation) => {
-            relation.attributes.forEach((attribute) => {
-              const rel = { relation: relation.relation, attributes: [attribute] };
-              allRelations.push({ action: action.action, relations: [rel] });
-            });
-          });
-        });
-        actionRelations.value = allRelations;
-        permissionVision.value = false;
+        location.reload();
       })
       .catch((error) => {
         handleError(error, toast);
@@ -117,16 +107,14 @@ export function useRBACUpdating(
       relation: relation,
       attributes: [attribute],
     };
-    apiService.rbac.addPermissions(form.context.values.role.id, [addPermissionReq]).catch((error) => {
-      handleError(error, toast);
-    });
-    actionVision.value = false;
-    if (actionRelations.value) {
-      const allRelations = actionRelations.value;
-      const rel = { relation: relation, attributes: [attribute] };
-      allRelations.push({ action: action, relations: [rel] });
-      actionRelations.value = allRelations;
-    }
+    apiService.rbac
+      .addPermissions(form.context.values.role.id, [addPermissionReq])
+      .then(() => {
+        location.reload();
+      })
+      .catch((error) => {
+        handleError(error, toast);
+      });
   };
 
   const handleDeleteUserPush = (user: UserResponse) => {


### PR DESCRIPTION
# Description

After adding or deleting a permission action in the RBAC interface, the local state update was either incorrect (delete showed stale rows) or optimistic without waiting for the API response (add updated state before the request completed). This led to visual glitches that could only be resolved by a manual page refresh.

The fix replaces the broken local state mutations in `handleDeletePermissionConfirmation` and `handleAddActionPush` with a `location.reload()` call inside the `.then()` handler, consistent with how `handleAddPermissionPush` already behaves.

## Related issues/external references

Fixes #793

## Types of changes

- Bug fix _(non-breaking change which fixes an issue)_
