### PR TITLE
Update auth store for renamed GEWIS PIN authentication API

### DIFF
--- a/lib/common/src/stores/auth.store.ts
+++ b/lib/common/src/stores/auth.store.ts
@@ -5,7 +5,7 @@ import type {
   AuthenticationLDAPRequest,
   AuthenticationPinRequest,
   AuthenticationResponse,
-  GEWISAuthenticationPinRequest,
+  MemberAuthenticationPinRequest,
   GewiswebAuthenticationRequest,
   UpdatePinRequest,
   UpdateLocalRequest,
@@ -14,7 +14,7 @@ import type {
   AcceptTosRequest,
   AuthenticationNfcRequest,
   AuthenticationLocalRequest,
-  GEWISAuthenticationSecurePinRequest,
+  MemberAuthenticationSecurePinRequest,
   AuthenticationSecureNfcRequest,
   AuthenticationSecurePinRequest,
 } from '@sudosos/sudosos-client';
@@ -96,12 +96,12 @@ export const useAuthStore = defineStore('auth', {
     },
 
     async gewisPinlogin(userId: string, pinCode: string, service: ApiService) {
-      const userDetails: GEWISAuthenticationPinRequest = {
-        gewisId: parseInt(userId, 10),
+      const userDetails: MemberAuthenticationPinRequest = {
+        memberId: parseInt(userId, 10),
         pin: pinCode,
       };
 
-      await service.authenticate.gewisPinAuthentication(userDetails).then((res) => {
+      await service.authenticate.memberPinAuthentication(userDetails).then((res) => {
         this.handleResponse(res.data, service);
       });
     },
@@ -112,13 +112,13 @@ export const useAuthStore = defineStore('auth', {
       posService: ApiService,
       service: ApiService,
     ) {
-      const req: GEWISAuthenticationSecurePinRequest = {
-        gewisId: parseInt(userId, 10),
+      const req: MemberAuthenticationSecurePinRequest = {
+        memberId: parseInt(userId, 10),
         pin: pinCode,
         posId,
       };
 
-      await posService.authenticate.secureGewisPINAuthentication(req).then((res) => {
+      await posService.authenticate.secureMemberPINAuthentication(req).then((res) => {
         this.handleResponse(res.data, service);
       });
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@commitlint/config-conventional": "^20.3.0",
     "@gewis/splash": "^2.4.0",
     "@primeuix/themes": "^2.0.2",
-    "@sudosos/sudosos-client": "github:GEWIS/sudosos-client#02703dea4f4f4f14545ee90b4e42cc8d7705c315",
+    "@sudosos/sudosos-client": "github:GEWIS/sudosos-client#f7d27403ac5a1f7d1f47b46cf1818055f9a3c333",
     "@tailwindcss/vite": "^4.1.17",
     "axios": "^1.13.2",
     "dinero.js": "^1.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1422,13 +1422,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sudosos/sudosos-client@github:GEWIS/sudosos-client#02703dea4f4f4f14545ee90b4e42cc8d7705c315":
+"@sudosos/sudosos-client@github:GEWIS/sudosos-client#f7d27403ac5a1f7d1f47b46cf1818055f9a3c333":
   version: 1.1.2
-  resolution: "@sudosos/sudosos-client@https://github.com/GEWIS/sudosos-client.git#commit=02703dea4f4f4f14545ee90b4e42cc8d7705c315"
+  resolution: "@sudosos/sudosos-client@https://github.com/GEWIS/sudosos-client.git#commit=f7d27403ac5a1f7d1f47b46cf1818055f9a3c333"
   dependencies:
     axios: "npm:^1.6.3"
     swagger-axios-codegen: "npm:^0.16.4"
-  checksum: 10c0/b5a95abd092c436d394c427139e70956713d0f8c9552a750b10aff4145c5561a9be5632601238727d1b42e3595295d882368520bf8adc1f7160b86f8b36c9ce6
+  checksum: 10c0/07393ac92321c65a8157e26e97d3d04c341e4fa0bca664067bdf0f90e0f354b32be00237200b531d52a1138d6049bfe930210ce1168162924e2290b7c68d045f
   languageName: node
   linkType: hard
 
@@ -7056,7 +7056,7 @@ __metadata:
     "@intlify/eslint-plugin-vue-i18n": "npm:^4.1.0"
     "@primeuix/themes": "npm:^2.0.2"
     "@rushstack/eslint-patch": "npm:^1.15.0"
-    "@sudosos/sudosos-client": "github:GEWIS/sudosos-client#02703dea4f4f4f14545ee90b4e42cc8d7705c315"
+    "@sudosos/sudosos-client": "github:GEWIS/sudosos-client#f7d27403ac5a1f7d1f47b46cf1818055f9a3c333"
     "@tailwindcss/vite": "npm:^4.1.17"
     "@tsconfig/node-lts": "npm:^24.0.0"
     "@types/dinero.js": "npm:^1.9.4"


### PR DESCRIPTION
# Description
Bumps `sudosos-client` to `f7d27403`. The new client renames the GEWIS-specific PIN authentication types and methods to generic member equivalents. Updated `auth.store.ts` accordingly.

> ⚠️ **This PR must be released in lockstep with the corresponding backend release.**

## Related issues/external references
N/A

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_