### PR TITLE
Add initial landing page for admins

### DIFF
--- a/apps/dashboard/src/components/CardComponent.vue
+++ b/apps/dashboard/src/components/CardComponent.vue
@@ -1,8 +1,9 @@
 <template>
   <Card
+    class="h-full"
     :pt="{
-      body: center ? 'flex-1' : '',
-      content: center ? 'h-full pb-[2rem]' : '',
+      body: `flex flex-col h-full${center ? ' flex-1' : ''}`,
+      content: `flex-1${center ? ' h-full pb-[2rem]' : ''}`,
     }"
   >
     <template #header>
@@ -14,9 +15,10 @@
     <template #content>
       <slot />
     </template>
-    <template v-if="action" #footer>
-      <Button id="bottom-left-button" class="w-full font-semibold" outlined @click="handleClick">
-        {{ action.toUpperCase() }}
+    <template v-if="action || $slots.footer" #footer>
+      <slot v-if="$slots.footer" name="footer" />
+      <Button v-else id="bottom-left-button" class="w-full font-semibold" outlined @click="handleClick">
+        {{ action?.toUpperCase() }}
       </Button>
     </template>
   </Card>

--- a/apps/dashboard/src/locales/en/modules/admin.json
+++ b/apps/dashboard/src/locales/en/modules/admin.json
@@ -96,6 +96,36 @@
       "websocket": {
         "title": "Websocket logs"
       },
+      "dashboard": {
+        "title": "Dashboard",
+        "empty": "Nothing to show 🎉",
+        "welcome": "Welcome back, {name}",
+        "viewAll": "View all",
+        "balanceSummary": {
+          "title": "Balance Overview",
+          "tooltip": "Shows combined balances for Members and Local Users only.",
+          "totalPositive": "Total positive balance",
+          "totalNegative": "Total negative balance",
+          "financialOverview": "Financial Overview",
+          "underConstruction": "Under construction",
+          "unavailable": "Balance data unavailable"
+        },
+        "pendingPayouts": {
+          "title": "Pending Payout Requests"
+        },
+        "pendingInvoices": {
+          "title": "Pending Invoices"
+        },
+        "negativeInvoiceAccounts": {
+          "title": "Negative Invoice Accounts"
+        },
+        "debtors": {
+          "title": "Users Eligible for Fines",
+          "totalDebt": "Total negative balance",
+          "totalFine": "Total fine to be issued",
+          "handoutFines": "Handout fines"
+        }
+      },
       "transactions": {
         "title": "Transaction Search",
         "search": "Search Transaction by ID",

--- a/apps/dashboard/src/locales/en/modules/admin.json
+++ b/apps/dashboard/src/locales/en/modules/admin.json
@@ -123,7 +123,7 @@
           "title": "Users Eligible for Fines",
           "totalDebt": "Total negative balance",
           "totalFine": "Total fine to be issued",
-          "handoutFines": "Handout fines"
+          "handoutFines": "Hand out fines"
         }
       },
       "transactions": {

--- a/apps/dashboard/src/locales/nl/modules/admin.json
+++ b/apps/dashboard/src/locales/nl/modules/admin.json
@@ -96,6 +96,36 @@
       "websocket": {
         "title": "Websocket logs"
       },
+      "dashboard": {
+        "title": "Dashboard",
+        "empty": "Niets te tonen 🎉",
+        "welcome": "Welkom terug, {name}",
+        "viewAll": "Bekijk alles",
+        "balanceSummary": {
+          "title": "Saldo overzicht",
+          "tooltip": "Toont gecombineerde saldo's voor Leden en Lokale Gebruikers.",
+          "totalPositive": "Totaal positief saldo",
+          "totalNegative": "Totaal negatief saldo",
+          "financialOverview": "Financieel overzicht",
+          "underConstruction": "In aanbouw",
+          "unavailable": "Saldobegegevens niet beschikbaar"
+        },
+        "pendingPayouts": {
+          "title": "Openstaande uitbetalingen"
+        },
+        "pendingInvoices": {
+          "title": "Openstaande facturen"
+        },
+        "negativeInvoiceAccounts": {
+          "title": "Factuuraccounts met negatief saldo"
+        },
+        "debtors": {
+          "title": "Gebruikers die in aanmerking komen voor boetes",
+          "totalDebt": "Totaal negatief saldo",
+          "totalFine": "Totale uit te geven boete",
+          "handoutFines": "Boetes uitdelen"
+        }
+      },
       "transactions": {
         "title": "Transactie zoeken",
         "search": "Zoek transactie op ID",

--- a/apps/dashboard/src/locales/pl/modules/admin.json
+++ b/apps/dashboard/src/locales/pl/modules/admin.json
@@ -96,6 +96,36 @@
       "websocket": {
         "title": "Logi WebSocket"
       },
+      "dashboard": {
+        "title": "Panel",
+        "empty": "Brak danych 🎉",
+        "welcome": "Witaj ponownie, {name}",
+        "viewAll": "Pokaż wszystko",
+        "balanceSummary": {
+          "title": "Przegląd salda",
+          "tooltip": "Pokazuje łączne salda tylko dla Członków i Użytkowników Lokalnych.",
+          "totalPositive": "Łączne saldo dodatnie",
+          "totalNegative": "Łączne saldo ujemne",
+          "financialOverview": "Przegląd finansowy",
+          "underConstruction": "W budowie",
+          "unavailable": "Dane salda niedostępne"
+        },
+        "pendingPayouts": {
+          "title": "Oczekujące wypłaty"
+        },
+        "pendingInvoices": {
+          "title": "Oczekujące faktury"
+        },
+        "negativeInvoiceAccounts": {
+          "title": "Konta faktur z ujemnym saldem"
+        },
+        "debtors": {
+          "title": "Użytkownicy kwalifikujący się do kar",
+          "totalDebt": "Łączne saldo ujemne",
+          "totalFine": "Łączna kara do wydania",
+          "handoutFines": "Wydaj kary"
+        }
+      },
       "rbac": {
         "title": "RBAC Management",
         "selection": {

--- a/apps/dashboard/src/modules/admin/routes.ts
+++ b/apps/dashboard/src/modules/admin/routes.ts
@@ -6,6 +6,7 @@ import AdminBannersView from '@/modules/admin/views/AdminBannersView.vue';
 import AdminSingleUserView from '@/modules/admin/views/AdminSingleUserView.vue';
 import AdminMaintainerView from '@/modules/admin/views/AdminMaintainerView.vue';
 import AdminRBACView from '@/modules/admin/views/AdminRBACView.vue';
+import AdminDashboardView from '@/modules/admin/views/AdminDashboardView.vue';
 
 export function adminRoutes(): RouteRecordRaw[] {
   return [
@@ -14,6 +15,16 @@ export function adminRoutes(): RouteRecordRaw[] {
       component: DashboardLayout,
       meta: { requiresAuth: true },
       children: [
+        {
+          path: '/admin',
+          component: AdminDashboardView,
+          name: 'adminDashboard',
+          meta: {
+            requiresAuth: true,
+            isAllowed: () => isAllowed('get', ['all'], 'User', ['any']),
+            title: 'modules.admin.dashboard.title',
+          },
+        },
         {
           path: '/user',
           name: 'users',

--- a/apps/dashboard/src/modules/admin/views/AdminDashboardView.vue
+++ b/apps/dashboard/src/modules/admin/views/AdminDashboardView.vue
@@ -1,0 +1,370 @@
+<template>
+  <PageContainer>
+    <div class="mb-3">
+      <h1 class="text-2xl font-semibold">
+        {{ t('modules.admin.dashboard.welcome', { name: currentUser?.firstName }) }}
+      </h1>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <!-- Balance Overview (full width) -->
+      <CardComponent class="md:col-span-2" :header="t('modules.admin.dashboard.balanceSummary.title')">
+        <template #topAction>
+          <i
+            v-tooltip.left="t('modules.admin.dashboard.balanceSummary.tooltip')"
+            class="pi pi-info-circle cursor-help text-muted-color"
+          />
+        </template>
+        <div class="flex flex-row items-stretch">
+          <!-- Balance figures -->
+          <div class="w-1/2">
+            <div v-if="loadingBalance" class="flex flex-row gap-8">
+              <Skeleton v-for="i in 2" :key="i" height="3rem" width="12rem" />
+            </div>
+            <div v-else-if="totalBalanceData" class="flex flex-row gap-12 py-2">
+              <div class="flex flex-col gap-1">
+                <span class="text-sm text-muted-color">{{
+                  t('modules.admin.dashboard.balanceSummary.totalPositive')
+                }}</span>
+                <span class="text-2xl font-bold text-green-600">{{ formatDineroObject(filteredTotalPositive) }}</span>
+              </div>
+              <div class="flex flex-col gap-1">
+                <span class="text-sm text-muted-color">{{
+                  t('modules.admin.dashboard.balanceSummary.totalNegative')
+                }}</span>
+                <span class="text-2xl font-bold text-red-500">{{ formatDineroObject(filteredTotalNegative) }}</span>
+              </div>
+            </div>
+            <div v-else class="py-2 text-sm text-muted-color">
+              {{ t('modules.admin.dashboard.balanceSummary.unavailable') }}
+            </div>
+          </div>
+
+          <Divider layout="vertical" />
+
+          <!-- Financial overview CTA -->
+          <div class="flex w-1/2 flex-col items-center justify-center gap-2 px-6">
+            <Button
+              disabled
+              icon="pi pi-chart-bar"
+              icon-pos="right"
+              :label="t('modules.admin.dashboard.balanceSummary.financialOverview')"
+            />
+            <span class="text-sm text-muted-color"
+              >🚧 {{ t('modules.admin.dashboard.balanceSummary.underConstruction') }} 🚧</span
+            >
+          </div>
+        </div>
+      </CardComponent>
+
+      <!-- Invoice Accounts with Negative Balance -->
+      <CardComponent :header="t('modules.admin.dashboard.negativeInvoiceAccounts.title')">
+        <template #topAction>
+          <Badge
+            v-if="!loadingNegativeAccounts && negativeAccountCount > 0"
+            severity="danger"
+            :value="negativeAccountCount"
+          />
+        </template>
+        <div v-if="loadingNegativeAccounts" class="flex flex-col gap-2">
+          <Skeleton v-for="i in 3" :key="i" class="w-full" height="2rem" />
+        </div>
+        <template v-else>
+          <p v-if="negativeAccountCount === 0" class="flex h-full items-center justify-center text-muted-color">
+            {{ t('modules.admin.dashboard.empty') }}
+          </p>
+          <DataTable v-else size="small" :value="negativeAccountsPreview">
+            <Column field="firstName" :header="t('common.name')" />
+            <Column :header="t('modules.financial.invoice.account.balance')">
+              <template #body="{ data }">
+                <span class="text-red-500">{{ formatPrice(data.amount) }}</span>
+              </template>
+            </Column>
+            <Column style="width: 3rem">
+              <template #body="{ data }">
+                <Button
+                  v-tooltip="t('modules.financial.invoice.create.create')"
+                  class="p-button-plain p-button-rounded p-button-text"
+                  icon="pi pi-file-edit"
+                  type="button"
+                  @click="navigateToInvoiceCreate(data.id)"
+                />
+              </template>
+            </Column>
+          </DataTable>
+        </template>
+        <template #footer>
+          <div class="flex justify-end">
+            <Button
+              icon="pi pi-arrow-right"
+              icon-pos="right"
+              :label="t('modules.admin.dashboard.viewAll')"
+              severity="secondary"
+              text
+              @click="() => router.push({ name: 'invoices' })"
+            />
+          </div>
+        </template>
+      </CardComponent>
+
+      <!-- Pending Invoices -->
+      <CardComponent :header="t('modules.admin.dashboard.pendingInvoices.title')">
+        <template #topAction>
+          <Badge v-if="!loadingInvoices && pendingInvoicesTotal > 0" severity="warn" :value="pendingInvoicesTotal" />
+        </template>
+        <div v-if="loadingInvoices" class="flex flex-col gap-2">
+          <Skeleton v-for="i in 3" :key="i" class="w-full" height="2rem" />
+        </div>
+        <template v-else>
+          <p v-if="pendingInvoices.length === 0" class="flex h-full items-center justify-center text-muted-color">
+            {{ t('modules.admin.dashboard.empty') }}
+          </p>
+          <DataTable v-else size="small" :value="pendingInvoices">
+            <Column :header="t('common.description')">
+              <template #body="{ data }">
+                <span class="cursor-pointer text-primary hover:underline" @click="navigateToInvoiceInfo(data.id)">{{
+                  data.description
+                }}</span>
+              </template>
+            </Column>
+            <Column :header="t('common.date')">
+              <template #body="{ data }">{{ formatDateFromString(data.date) }}</template>
+            </Column>
+          </DataTable>
+        </template>
+        <template #footer>
+          <div class="flex justify-end">
+            <Button
+              icon="pi pi-arrow-right"
+              icon-pos="right"
+              :label="t('modules.admin.dashboard.viewAll')"
+              severity="secondary"
+              text
+              @click="() => router.push({ name: 'invoices' })"
+            />
+          </div>
+        </template>
+      </CardComponent>
+
+      <!-- Users Eligible for Fines -->
+      <CardComponent :header="t('modules.admin.dashboard.debtors.title')">
+        <template #topAction>
+          <Badge
+            v-if="!debtorStore.isDebtorsLoading && debtorStore.allDebtors.length > 0"
+            severity="danger"
+            :value="debtorStore.allDebtors.length"
+          />
+        </template>
+        <div v-if="debtorStore.isDebtorsLoading" class="flex flex-col gap-2">
+          <Skeleton v-for="i in 3" :key="i" class="w-full" height="2rem" />
+        </div>
+        <template v-else>
+          <p
+            v-if="debtorStore.allDebtors.length === 0"
+            class="flex h-full items-center justify-center text-muted-color"
+          >
+            {{ t('modules.admin.dashboard.empty') }}
+          </p>
+          <div v-else class="flex flex-col gap-3 pt-2">
+            <div class="flex justify-between items-center">
+              <span>{{ t('modules.admin.dashboard.debtors.totalDebt') }}</span>
+              <span class="font-bold text-red-500">{{ formatPrice(debtorStore.totalDebt) }}</span>
+            </div>
+            <div class="flex justify-between items-center">
+              <span>{{ t('modules.admin.dashboard.debtors.totalFine') }}</span>
+              <span class="font-bold">{{ formatPrice(debtorStore.totalFine) }}</span>
+            </div>
+          </div>
+        </template>
+        <template #footer>
+          <div class="flex justify-end">
+            <Button
+              icon="pi pi-arrow-right"
+              icon-pos="right"
+              :label="t('modules.admin.dashboard.debtors.handoutFines')"
+              severity="secondary"
+              text
+              @click="() => router.push({ name: 'Debtors' })"
+            />
+          </div>
+        </template>
+      </CardComponent>
+
+      <!-- Pending Payout Requests -->
+      <CardComponent :header="t('modules.admin.dashboard.pendingPayouts.title')">
+        <template #topAction>
+          <Badge v-if="!loadingPayouts && pendingPayoutsTotal > 0" severity="warn" :value="pendingPayoutsTotal" />
+        </template>
+        <div v-if="loadingPayouts" class="flex flex-col gap-2">
+          <Skeleton v-for="i in 3" :key="i" class="w-full" height="2rem" />
+        </div>
+        <template v-else>
+          <p v-if="pendingPayouts.length === 0" class="flex h-full items-center justify-center text-muted-color">
+            {{ t('modules.admin.dashboard.empty') }}
+          </p>
+          <DataTable v-else size="small" :value="pendingPayouts">
+            <Column field="requestedBy.firstName" :header="t('modules.financial.payout.requestedBy')" />
+            <Column :header="t('common.amount')">
+              <template #body="{ data }">{{ formatPrice(data.amount) }}</template>
+            </Column>
+            <Column :header="t('common.date')">
+              <template #body="{ data }">{{ formatDateFromString(data.createdAt) }}</template>
+            </Column>
+          </DataTable>
+        </template>
+        <template #footer>
+          <div class="flex justify-end">
+            <Button
+              icon="pi pi-arrow-right"
+              icon-pos="right"
+              :label="t('modules.admin.dashboard.viewAll')"
+              severity="secondary"
+              text
+              @click="() => router.push({ name: 'payouts' })"
+            />
+          </div>
+        </template>
+      </CardComponent>
+    </div>
+  </PageContainer>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { InvoiceStatusResponseStateEnum } from '@sudosos/sudosos-client';
+import type {
+  BasePayoutRequestResponse,
+  BalanceResponse,
+  DineroObjectResponse,
+  InvoiceResponse,
+  TotalBalanceResponse,
+  UserTypeTotalBalanceResponse,
+} from '@sudosos/sudosos-client';
+import DataTable from 'primevue/datatable';
+import Column from 'primevue/column';
+import Skeleton from 'primevue/skeleton';
+import Badge from 'primevue/badge';
+import Divider from 'primevue/divider';
+import { useAuthStore } from '@sudosos/sudosos-frontend-common';
+import PageContainer from '@/layout/PageContainer.vue';
+import CardComponent from '@/components/CardComponent.vue';
+import { formatPrice, formatDateFromString, formatDineroObject } from '@/utils/formatterUtils';
+import { usePayoutStore } from '@/stores/payout.store';
+import { useInvoiceStore } from '@/stores/invoice.store';
+import { useDebtorStore } from '@/stores/debtor.store';
+import apiService from '@/services/ApiService';
+import router from '@/router';
+
+const { t } = useI18n();
+
+const authStore = useAuthStore();
+const payoutStore = usePayoutStore();
+const invoiceStore = useInvoiceStore();
+const debtorStore = useDebtorStore();
+
+const currentUser = computed(() => authStore.getUser);
+
+// Balance summary
+const loadingBalance = ref(true);
+const totalBalanceData = ref<TotalBalanceResponse | null>(null);
+
+const BALANCE_USER_TYPES = ['MEMBER', 'LOCAL_USER'];
+
+const filteredUserTypeBalances = computed<UserTypeTotalBalanceResponse[]>(() => {
+  if (!totalBalanceData.value) return [];
+  const all = (totalBalanceData.value.userTypeBalances as unknown as UserTypeTotalBalanceResponse[]) ?? [];
+  console.log('[AdminDashboard] userTypeBalances raw:', all);
+  const filtered = all.filter((b) => BALANCE_USER_TYPES.includes(b.userType));
+  console.log('[AdminDashboard] filtered (MEMBER + LOCAL_USER):', filtered);
+  return filtered;
+});
+
+const filteredTotalPositive = computed<DineroObjectResponse | null>(() => {
+  if (!filteredUserTypeBalances.value.length) return null;
+  const base = filteredUserTypeBalances.value[0].totalPositive;
+  return {
+    ...base,
+    amount: filteredUserTypeBalances.value.reduce((sum, b) => sum + b.totalPositive.amount, 0),
+  };
+});
+
+const filteredTotalNegative = computed<DineroObjectResponse | null>(() => {
+  if (!filteredUserTypeBalances.value.length) return null;
+  const base = filteredUserTypeBalances.value[0].totalNegative;
+  return {
+    ...base,
+    amount: filteredUserTypeBalances.value.reduce((sum, b) => sum + b.totalNegative.amount, 0),
+  };
+});
+
+// Pending payouts
+const loadingPayouts = ref(true);
+const pendingPayouts = ref<BasePayoutRequestResponse[]>([]);
+const pendingPayoutsTotal = ref(0);
+
+// Pending invoices
+const loadingInvoices = ref(true);
+const pendingInvoices = ref<InvoiceResponse[]>([]);
+const pendingInvoicesTotal = ref(0);
+
+// Negative invoice accounts
+const loadingNegativeAccounts = ref(true);
+const negativeAccounts = computed<BalanceResponse[]>(() => Object.values(invoiceStore.negativeInvoiceUsers));
+const negativeAccountCount = computed(() => negativeAccounts.value.length);
+const negativeAccountsPreview = computed(() => negativeAccounts.value.slice(0, 5));
+
+const navigateToInvoiceInfo = (invoiceId: number) => {
+  void router.push({ name: 'invoiceInfo', params: { id: invoiceId } });
+};
+
+const navigateToInvoiceCreate = (userId: number) => {
+  void router.push({ name: 'invoiceCreate', query: { userId } });
+};
+
+onMounted(async () => {
+  const now = new Date();
+  await Promise.allSettled([
+    apiService.balance
+      .calculateTotalBalances(now.toISOString().split('T')[0])
+      .then((res) => {
+        console.log('[AdminDashboard] calculateTotalBalances response:', res.data);
+        totalBalanceData.value = res.data;
+      })
+      .catch((err) => {
+        console.warn('[AdminDashboard] calculateTotalBalances failed:', err);
+      })
+      .finally(() => {
+        loadingBalance.value = false;
+      }),
+
+    payoutStore
+      .fetchPayouts(5, 0, 'CREATED')
+      .then((res) => {
+        pendingPayouts.value = res.records;
+        pendingPayoutsTotal.value = res._pagination.count ?? 0;
+      })
+      .finally(() => {
+        loadingPayouts.value = false;
+      }),
+
+    invoiceStore
+      .fetchInvoices(5, 0, { state: InvoiceStatusResponseStateEnum.Created })
+      .then((res) => {
+        pendingInvoices.value = res.records as InvoiceResponse[];
+        pendingInvoicesTotal.value = res._pagination.count ?? 0;
+      })
+      .finally(() => {
+        loadingInvoices.value = false;
+      }),
+
+    invoiceStore.fetchUsersIfEmpty().finally(() => {
+      loadingNegativeAccounts.value = false;
+    }),
+
+    debtorStore.fetchCalculatedFines(now, now),
+  ]);
+});
+</script>
+
+<style scoped lang="scss"></style>

--- a/apps/dashboard/src/modules/admin/views/AdminDashboardView.vue
+++ b/apps/dashboard/src/modules/admin/views/AdminDashboardView.vue
@@ -280,19 +280,19 @@ const filteredUserTypeBalances = computed<UserTypeTotalBalanceResponse[]>(() => 
 });
 
 const filteredTotalPositive = computed<DineroObjectResponse | null>(() => {
-  if (!filteredUserTypeBalances.value.length) return null;
-  const base = filteredUserTypeBalances.value[0].totalPositive;
+  const first = filteredUserTypeBalances.value[0];
+  if (!first) return null;
   return {
-    ...base,
+    ...first.totalPositive,
     amount: filteredUserTypeBalances.value.reduce((sum, b) => sum + b.totalPositive.amount, 0),
   };
 });
 
 const filteredTotalNegative = computed<DineroObjectResponse | null>(() => {
-  if (!filteredUserTypeBalances.value.length) return null;
-  const base = filteredUserTypeBalances.value[0].totalNegative;
+  const first = filteredUserTypeBalances.value[0];
+  if (!first) return null;
   return {
-    ...base,
+    ...first.totalNegative,
     amount: filteredUserTypeBalances.value.reduce((sum, b) => sum + b.totalNegative.amount, 0),
   };
 });
@@ -321,7 +321,7 @@ onMounted(async () => {
   const now = new Date();
   await Promise.allSettled([
     apiService.balance
-      .calculateTotalBalances(now.toISOString().split('T')[0])
+      .calculateTotalBalances(now.toISOString().split('T')[0] ?? '')
       .then((res) => {
         totalBalanceData.value = res.data;
       })

--- a/apps/dashboard/src/modules/admin/views/AdminDashboardView.vue
+++ b/apps/dashboard/src/modules/admin/views/AdminDashboardView.vue
@@ -21,7 +21,7 @@
             <div v-if="loadingBalance" class="flex flex-row gap-8">
               <Skeleton v-for="i in 2" :key="i" height="3rem" width="12rem" />
             </div>
-            <div v-else-if="totalBalanceData" class="flex flex-row gap-12 py-2">
+            <div v-else-if="filteredTotalPositive && filteredTotalNegative" class="flex flex-row gap-12 py-2">
               <div class="flex flex-col gap-1">
                 <span class="text-sm text-muted-color">{{
                   t('modules.admin.dashboard.balanceSummary.totalPositive')
@@ -122,9 +122,11 @@
           <DataTable v-else size="small" :value="pendingInvoices">
             <Column :header="t('common.description')">
               <template #body="{ data }">
-                <span class="cursor-pointer text-primary hover:underline" @click="navigateToInvoiceInfo(data.id)">{{
-                  data.description
-                }}</span>
+                <router-link
+                  class="text-primary hover:underline"
+                  :to="{ name: 'invoiceInfo', params: { id: data.id } }"
+                  >{{ data.description }}</router-link
+                >
               </template>
             </Column>
             <Column :header="t('common.date')">
@@ -274,10 +276,7 @@ const BALANCE_USER_TYPES = ['MEMBER', 'LOCAL_USER'];
 const filteredUserTypeBalances = computed<UserTypeTotalBalanceResponse[]>(() => {
   if (!totalBalanceData.value) return [];
   const all = (totalBalanceData.value.userTypeBalances as unknown as UserTypeTotalBalanceResponse[]) ?? [];
-  console.log('[AdminDashboard] userTypeBalances raw:', all);
-  const filtered = all.filter((b) => BALANCE_USER_TYPES.includes(b.userType));
-  console.log('[AdminDashboard] filtered (MEMBER + LOCAL_USER):', filtered);
-  return filtered;
+  return all.filter((b) => BALANCE_USER_TYPES.includes(b.userType));
 });
 
 const filteredTotalPositive = computed<DineroObjectResponse | null>(() => {
@@ -314,10 +313,6 @@ const negativeAccounts = computed<BalanceResponse[]>(() => Object.values(invoice
 const negativeAccountCount = computed(() => negativeAccounts.value.length);
 const negativeAccountsPreview = computed(() => negativeAccounts.value.slice(0, 5));
 
-const navigateToInvoiceInfo = (invoiceId: number) => {
-  void router.push({ name: 'invoiceInfo', params: { id: invoiceId } });
-};
-
 const navigateToInvoiceCreate = (userId: number) => {
   void router.push({ name: 'invoiceCreate', query: { userId } });
 };
@@ -328,7 +323,6 @@ onMounted(async () => {
     apiService.balance
       .calculateTotalBalances(now.toISOString().split('T')[0])
       .then((res) => {
-        console.log('[AdminDashboard] calculateTotalBalances response:', res.data);
         totalBalanceData.value = res.data;
       })
       .catch((err) => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

Adds an admin landing page that can be used after splitting the frontend into a user and admin app (see #775 )

<img width="1314" height="921" alt="image" src="https://github.com/user-attachments/assets/3140f8c3-c935-4583-85d9-2c67667df486" />


## Related issues/external references

#775 
## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_