### PR TITLE
fix: user profile card width

### DIFF
--- a/apps/dashboard/src/modules/user/components/UserInfo.vue
+++ b/apps/dashboard/src/modules/user/components/UserInfo.vue
@@ -1,11 +1,11 @@
 <template>
   <CardComponent :header="t('components.general.quickOverview.header')">
     <div v-if="props.user" class="@container">
-      <div class="flex flex-col-reverse @sm:flex-row @sm:justify-center items-center gap-2">
-        <span class="text-2xl font-bold text-center"> {{ props.user.firstName }} {{ props.user.lastName }} </span>
+      <div class="flex flex-col items-center gap-2 overflow-hidden">
         <span class="text-2xl text-center font-mono font-semibold text-gray-500">
           {{ props.user.memberId ? props.user.memberId : `E${props.user.id}` }}
         </span>
+        <span class="text-2xl font-bold text-center"> {{ props.user.firstName }} {{ props.user.lastName }} </span>
       </div>
       <p v-if="!props.user.ofAge" class="font-bold text-center text-red-500 mt-2">
         {{ t('components.general.quickOverview.underAge') }}

--- a/apps/dashboard/src/modules/user/views/UserProfileView.vue
+++ b/apps/dashboard/src/modules/user/views/UserProfileView.vue
@@ -9,8 +9,8 @@
         <UserPinComponent />
         <UserSettingsComponent :user="current.user" />
       </div>
-      <div class="flex flex-col justify-start items-start flex-1 gap-4">
-        <UserInfo class="self-start shrink-0 hidden md:block" :user="current.user" />
+      <div class="hidden md:flex flex-col gap-4 flex-1">
+        <UserInfo :user="current.user" />
         <UserNotificationPreferencesComponent :user="current.user" />
       </div>
     </div>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Makes it so that all the cards on the user profile have the same width.

Before:
<img width="1342" height="946" alt="image" src="https://github.com/user-attachments/assets/fbe2222c-17b4-4658-8053-2a2293e61a97" />

After:
<img width="1342" height="946" alt="image" src="https://github.com/user-attachments/assets/483c9cd3-6fe3-4284-8d02-7dca02efe0b7" />

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Style _(Change that do not affect the functionality of the code)_
