### PR TITLE
feat: unify composables into one useTransferTableYear composable

### DIFF
--- a/apps/dashboard/src/composables/dataTableYear.ts
+++ b/apps/dashboard/src/composables/dataTableYear.ts
@@ -1,5 +1,14 @@
 import { ref, watch, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
 import type { DataTablePageEvent } from 'primevue/datatable';
+import type { LocationQuery } from 'vue-router';
+
+export interface QueryParamSync<F> {
+  yearKey?: string;
+  searchKey?: string;
+  serializeFilters?: (filters: F) => Record<string, string | undefined>;
+  deserializeFilters?: (query: LocationQuery) => Partial<F>;
+}
 
 export function useDataTableYear<T, F extends Record<string, unknown>>(
   fetchRecords: (params: {
@@ -14,17 +23,71 @@ export function useDataTableYear<T, F extends Record<string, unknown>>(
     defaultYear: number;
     initialFilters?: F;
     defaultRows?: number;
+    queryParamSync?: QueryParamSync<F>;
   },
 ) {
-  const yearnumber = options?.defaultYear ?? options?.yearList[0];
-  const year = ref(yearnumber?.toString() ?? '');
+  const qps = options?.queryParamSync;
+  const route = useRoute();
+  const DEFAULT_YEAR_KEY = 'year';
+
+  // --- Initialize state, optionally from URL query params ---
+  const defaultYearNum = options?.defaultYear ?? options?.yearList?.[0];
+  let yearInit = defaultYearNum?.toString() ?? '';
+  if (qps) {
+    const key = qps.yearKey ?? DEFAULT_YEAR_KEY;
+    const q = route.query[key];
+    if (typeof q === 'string' && q) {
+      const parsed = Number(q);
+      const validYears = options?.yearList;
+      if (!isNaN(parsed) && (!validYears || validYears.includes(parsed))) {
+        yearInit = q;
+      }
+    }
+  }
+  const year = ref(yearInit);
+
   const page = ref(0);
   const rows = ref(options?.defaultRows ?? 10);
-  const filters = ref({ ...(options?.initialFilters || {}) } as F);
+
+  let filtersInit = { ...(options?.initialFilters || {}) } as F;
+  if (qps?.deserializeFilters) {
+    const fromQuery = qps.deserializeFilters(route.query);
+    // Only apply defined values so URL absence does not override initialFilters
+    const defined = Object.fromEntries(Object.entries(fromQuery).filter(([, v]) => v !== undefined)) as Partial<F>;
+    filtersInit = { ...filtersInit, ...defined } as F;
+  }
+  const filters = ref(filtersInit);
+
+  let searchInit = '';
+  if (qps?.searchKey) {
+    const q = route.query[qps.searchKey];
+    if (typeof q === 'string' && q) searchInit = q;
+  }
+  const search = ref(searchInit);
+
   const isLoading = ref(false);
   const records = ref<T[]>([]);
   const totalRecords = ref(0);
 
+  // Uses window.history.replaceState directly to avoid triggering navigation guards,
+  // which can cause infinite redirect loops in apps with complex guard logic.
+  function syncToUrl() {
+    if (!qps) return;
+    const yearKey = qps.yearKey ?? DEFAULT_YEAR_KEY;
+    const raw: Record<string, string | undefined> = {
+      [yearKey]: year.value || undefined,
+      ...(qps.serializeFilters ? qps.serializeFilters(filters.value) : {}),
+      ...(qps.searchKey ? { [qps.searchKey]: search.value || undefined } : {}),
+    };
+    const params = new URLSearchParams();
+    for (const [k, v] of Object.entries(raw)) {
+      if (v !== undefined) params.set(k, v);
+    }
+    const qs = params.toString();
+    window.history.replaceState(window.history.state, '', `${route.path}${qs ? `?${qs}` : ''}`);
+  }
+
+  // --- Core logic ---
   async function reload() {
     isLoading.value = true;
     records.value = new Array(rows.value) as T[];
@@ -46,7 +109,7 @@ export function useDataTableYear<T, F extends Record<string, unknown>>(
   }
 
   function setFilter<K extends keyof F>(key: K, value: F[K]) {
-    filters.value[key] = value;
+    filters.value[key] = (value === null ? undefined : value) as F[K];
     page.value = 0;
     void reload();
   }
@@ -55,22 +118,43 @@ export function useDataTableYear<T, F extends Record<string, unknown>>(
     if (!id || isNaN(id)) return reload();
     page.value = 0;
     if (fetchSingleRecord) {
+      isLoading.value = true;
       records.value = [await fetchSingleRecord(id)];
+      totalRecords.value = 1;
+      isLoading.value = false;
     }
   }
 
+  // Reload when year or filters change
   watch([year, filters], () => {
     page.value = 0;
     void reload();
   });
 
-  onMounted(reload);
+  // Sync URL on year, filter, or search change
+  if (qps) {
+    watch([year, search], syncToUrl);
+    watch(filters, syncToUrl, { deep: true });
+  }
+
+  onMounted(() => {
+    // If a search ID was restored from the URL, show that single record immediately
+    if (qps?.searchKey && search.value) {
+      const id = Number(search.value);
+      if (!isNaN(id) && id > 0) {
+        void onSingle(id).catch(() => void reload());
+        return;
+      }
+    }
+    void reload();
+  });
 
   return {
     year,
     page,
     rows,
     filters,
+    search,
     isLoading,
     records,
     totalRecords,

--- a/apps/dashboard/src/composables/transferTableYear.ts
+++ b/apps/dashboard/src/composables/transferTableYear.ts
@@ -1,0 +1,99 @@
+import { useI18n } from 'vue-i18n';
+import { useToast } from 'primevue/usetoast';
+import type { LocationQuery } from 'vue-router';
+import { useFiscalYear } from '@/composables/fiscalYear';
+import { useDataTableYear } from '@/composables/dataTableYear';
+
+/**
+ * Composable for transfer-type DataTables with fiscal year tabs, ID search, and optional URL query-param sync.
+ *
+ * ## URL initialisation
+ * Pass `syncQueryParams: true` (or a `TransferFilterSync` object for filter serialization) to have the
+ * composable read its initial state from the URL on mount and keep the URL in sync as state changes:
+ *
+ *   /financial/invoices?year=2025&id=42&state=CREATED
+ *
+ * Any page can deep-link to a pre-filtered table by navigating with those params.
+ *
+ * ## Cross-page filter passing
+ * To navigate from another page with pre-populated filters, use `router.push` with the target route
+ * and the relevant query params:
+ *
+ *   router.push({ name: 'invoiceOverview', query: { year: '2025', state: 'CREATED' } })
+ *   router.push({ name: 'payoutOverview',  query: { year: '2025', id: '42' } })
+ *
+ * ## Query param names per table
+ * | Table       | `year`             | `id`           | filter keys |
+ * | ----------- | ------------------ | -------------- | ----------- |
+ * | Invoices    | fiscal year number | invoice ID     | `state`     |
+ * | Write-offs  | fiscal year number | write-off ID   | —           |
+ * | Payouts     | fiscal year number | payout ID      | `state`     |
+ */
+export interface TransferFilterSync<F> {
+  serializeFilters?: (filters: F) => Record<string, string | undefined>;
+  deserializeFilters?: (query: LocationQuery) => Partial<F>;
+}
+
+export function useTransferTableYear<T, F extends Record<string, unknown>>(
+  fetchRecords: (params: {
+    year: number;
+    page: number;
+    rows: number;
+    filters: F;
+    fiscalStart: string;
+    fiscalEnd: string;
+  }) => Promise<{ records: T[]; _pagination: { count: number } }>,
+  fetchSingleRecord?: (id: number) => Promise<T>,
+  options?: {
+    initialFilters?: F;
+    defaultRows?: number;
+    syncQueryParams?: boolean | TransferFilterSync<F>;
+  },
+) {
+  const { getFiscalYearList, getFiscalYearRange } = useFiscalYear();
+  const years = getFiscalYearList();
+  const { t } = useI18n();
+  const toast = useToast();
+
+  async function wrappedFetch(params: { year: number; page: number; rows: number; filters: F }) {
+    const { start, end } = getFiscalYearRange(params.year);
+    return fetchRecords({ ...params, fiscalStart: start, fiscalEnd: end });
+  }
+
+  const syncOpts = options?.syncQueryParams;
+  const filterSync: TransferFilterSync<F> | undefined = syncOpts && typeof syncOpts === 'object' ? syncOpts : undefined;
+
+  const table = useDataTableYear<T, F>(wrappedFetch, fetchSingleRecord, {
+    yearList: years,
+    defaultYear: years[0]!,
+    initialFilters: options?.initialFilters,
+    defaultRows: options?.defaultRows,
+    queryParamSync: syncOpts
+      ? {
+          yearKey: 'year',
+          searchKey: 'id',
+          serializeFilters: filterSync?.serializeFilters,
+          deserializeFilters: filterSync?.deserializeFilters,
+        }
+      : undefined,
+  });
+
+  function searchById() {
+    const id = Number(table.search.value);
+    if (isNaN(id)) return;
+    table.onSingle(id).catch(() => {
+      toast.add({
+        severity: 'warn',
+        summary: t('common.toast.info.info'),
+        detail: t('common.toast.info.notFound'),
+        life: 3000,
+      });
+    });
+  }
+
+  return {
+    ...table,
+    years,
+    searchById,
+  };
+}

--- a/apps/dashboard/src/modules/admin/views/AdminDashboardView.vue
+++ b/apps/dashboard/src/modules/admin/views/AdminDashboardView.vue
@@ -331,7 +331,7 @@ onMounted(async () => {
       }),
 
     payoutStore
-      .fetchPayouts(5, 0, 'CREATED')
+      .fetchPayouts(5, 0, { status: 'CREATED' })
       .then((res) => {
         pendingPayouts.value = res.records;
         pendingPayoutsTotal.value = res._pagination.count ?? 0;

--- a/apps/dashboard/src/modules/financial/components/invoice/InvoiceTableYear.vue
+++ b/apps/dashboard/src/modules/financial/components/invoice/InvoiceTableYear.vue
@@ -2,7 +2,7 @@
   <IconField icon-position="left">
     <InputIcon class="pi pi-search" />
     <InputText
-      v-model="searchId"
+      v-model="search"
       :placeholder="t('common.id')"
       @focusout="searchById"
       @keyup.enter="searchById"
@@ -25,68 +25,53 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useToast } from 'primevue/usetoast';
-import { type InvoiceResponseTypes, type InvoiceStatusResponseStateEnum } from '@gewis/sudosos-client';
+import { type InvoiceResponseTypes, InvoiceStatusResponseStateEnum } from '@gewis/sudosos-client';
 import InvoiceTable from '@/modules/financial/components/invoice/InvoiceTable.vue';
-import { useFiscalYear } from '@/composables/fiscalYear';
 import { useInvoiceStore } from '@/stores/invoice.store';
-import { useDataTableYear } from '@/composables/dataTableYear';
+import { useTransferTableYear } from '@/composables/transferTableYear';
 
-const { getFiscalYearList, getFiscalYearRange } = useFiscalYear();
-const years = getFiscalYearList();
 const invoiceStore = useInvoiceStore();
-const filterState = ref<InvoiceStatusResponseStateEnum | undefined>(undefined);
-const searchId = ref<string | null>(null);
-
 const { t } = useI18n();
-const toast = useToast();
 
 async function fetchInvoices({
-  year,
   page,
   rows,
   filters,
+  fiscalStart,
+  fiscalEnd,
 }: {
   year: number;
   page: number;
   rows: number;
   filters: { state?: InvoiceStatusResponseStateEnum };
+  fiscalStart: string;
+  fiscalEnd: string;
 }) {
-  const { start, end } = getFiscalYearRange(year);
-  const queryParams = {
-    fromDate: start,
-    tillDate: end,
-    ...(filters?.state ? { state: filters.state } : {}),
-  };
-  return await invoiceStore.fetchInvoices(rows, page, queryParams);
+  return await invoiceStore.fetchInvoices(rows, page, {
+    fromDate: fiscalStart,
+    tillDate: fiscalEnd,
+    state: filters.state,
+  });
 }
 
 async function fetchSingleInvoice(id: number) {
   return await invoiceStore.fetchInvoice(id);
 }
 
-const { year, rows, isLoading, records, totalRecords, onPage, setFilter, onSingle } = useDataTableYear<
-  InvoiceResponseTypes,
-  { state?: InvoiceStatusResponseStateEnum }
->(fetchInvoices, fetchSingleInvoice, {
-  yearList: years,
-  defaultYear: years[0]!,
-  initialFilters: { state: filterState.value },
-  defaultRows: 10,
-});
-
-function searchById() {
-  const id = Number(searchId.value);
-  if (isNaN(id)) return;
-  onSingle(id).catch(() => {
-    toast.add({
-      severity: 'warn',
-      summary: t('common.toast.info.info'),
-      detail: t('common.toast.info.notFound'),
-      life: 3000,
-    });
-  });
-}
+const { year, years, search, rows, isLoading, records, totalRecords, onPage, setFilter, searchById } =
+  useTransferTableYear<InvoiceResponseTypes, { state?: InvoiceStatusResponseStateEnum }>(
+    fetchInvoices,
+    fetchSingleInvoice,
+    {
+      initialFilters: { state: undefined },
+      defaultRows: 10,
+      syncQueryParams: {
+        serializeFilters: (f) => ({ state: f.state }),
+        deserializeFilters: (q) => ({
+          state: typeof q.state === 'string' ? (q.state as InvoiceStatusResponseStateEnum) : undefined,
+        }),
+      },
+    },
+  );
 </script>

--- a/apps/dashboard/src/modules/financial/components/payout/PayoutTable.vue
+++ b/apps/dashboard/src/modules/financial/components/payout/PayoutTable.vue
@@ -3,31 +3,63 @@
     <DataTable
       class="w-full"
       data-key="id"
+      filter-display="menu"
+      :filters="filters"
       lazy
-      :paginator="paginator"
+      :paginator="true"
       :rows="rows"
       :rows-per-page-options="[5, 10, 25, 50, 100]"
       table-style="min-width: 50rem"
       :total-records="totalRecords"
-      :value="rowValues"
-      @page="onPage($event)"
+      :value="payouts"
+      @page="onPage"
     >
-      <Column field="date" :header="t('common.date')">
+      <Column field="id" :header="t('common.id')">
+        <template #body="slotProps">
+          <Skeleton v-if="isLoading" class="h-1rem my-1 surface-300 w-6" />
+          <span v-else>{{ slotProps.data.id }}</span>
+        </template>
+      </Column>
+      <Column field="createdAt" :header="t('common.date')">
         <template #body="slotProps">
           <Skeleton v-if="isLoading" class="h-1rem my-1 surface-300 w-6" />
           <span v-else>{{ formatDateFromString(slotProps.data.createdAt) }}</span>
         </template>
       </Column>
-      <Column field="status" :header="t('common.status')">
-        <template #body>
+      <Column
+        field="status"
+        filter
+        filter-match-mode="equals"
+        :header="t('common.status')"
+        :show-apply-button="false"
+        :show-clear-button="false"
+        :show-filter-match-modes="false"
+      >
+        <template #filter="{ filterModel }">
+          <Select
+            v-model="filterModel.value"
+            option-label="name"
+            option-value="value"
+            :options="states"
+            :placeholder="t('common.placeholders.selectType')"
+            @change="(e) => stateFilterChange('state', e)"
+          />
+        </template>
+        <template #body="slotProps">
           <Skeleton v-if="isLoading" class="h-1rem my-1 surface-300 w-6" />
-          <span v-else>{{ state }}</span>
+          <span v-else>{{ slotProps.data.status }}</span>
         </template>
       </Column>
       <Column field="requestedBy.firstName" :header="t('modules.financial.payout.requestedBy')">
         <template #body="slotProps">
           <Skeleton v-if="isLoading" class="h-1rem my-1 surface-300 w-6" />
           <span v-else>{{ slotProps.data.requestedBy.firstName }}</span>
+        </template>
+      </Column>
+      <Column field="approvedBy.firstName" :header="t('modules.financial.payout.approvedBy')">
+        <template #body="slotProps">
+          <Skeleton v-if="isLoading" class="h-1rem my-1 surface-300 w-6" />
+          <span v-else>{{ slotProps.data.approvedBy ? slotProps.data.approvedBy.firstName : t('common.na') }}</span>
         </template>
       </Column>
       <Column field="amount" :header="t('common.amount')">
@@ -74,11 +106,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, type PropType, type Ref, computed, watch } from 'vue';
-import { type PaginatedBasePayoutRequestResponse, PayoutRequestStatusRequestStateEnum } from '@gewis/sudosos-client';
+import { ref, type Ref } from 'vue';
+import { type BasePayoutRequestResponse, PayoutRequestStatusRequestStateEnum } from '@gewis/sudosos-client';
 import DataTable, { type DataTablePageEvent } from 'primevue/datatable';
 import Column from 'primevue/column';
 import Button from 'primevue/button';
+import { type SelectChangeEvent } from 'primevue/select';
 import { useI18n } from 'vue-i18n';
 import { addListenerOnDialogueOverlay } from '@sudosos/sudosos-frontend-common';
 import { formatPrice, formatDateFromString } from '@/utils/formatterUtils';
@@ -86,32 +119,42 @@ import { usePayoutStore } from '@/stores/payout.store';
 import { getPayoutPdfSrc } from '@/utils/urlUtils';
 import PayoutInfo from '@/modules/financial/components/payout/PayoutInfo.vue';
 
+defineProps<{
+  payouts: BasePayoutRequestResponse[];
+  isLoading: boolean;
+  rows: number;
+  totalRecords: number;
+}>();
+
+const emit = defineEmits(['page', 'stateFilterChange']);
+
 const { t } = useI18n();
-
-const props = defineProps({
-  state: {
-    type: String as PropType<PayoutRequestStatusRequestStateEnum>,
-    required: true,
-  },
-});
-
 const payoutStore = usePayoutStore();
-const totalRecords = ref<number>(0);
-const isLoading = ref<boolean>(true);
 
-const rows = ref<number>(5);
-const paginator = ref<boolean>(true);
+const states: Ref<Array<{ name: string; value: string | null }>> = ref([
+  { name: PayoutRequestStatusRequestStateEnum.Created, value: PayoutRequestStatusRequestStateEnum.Created },
+  { name: PayoutRequestStatusRequestStateEnum.Approved, value: PayoutRequestStatusRequestStateEnum.Approved },
+  { name: PayoutRequestStatusRequestStateEnum.Denied, value: PayoutRequestStatusRequestStateEnum.Denied },
+  { name: PayoutRequestStatusRequestStateEnum.Cancelled, value: PayoutRequestStatusRequestStateEnum.Cancelled },
+  { name: 'ALL', value: null },
+]);
 
-const payoutRequests = ref();
-const rowValues = computed(() => {
-  if (isLoading.value) return Array(rows.value).fill(null);
-  return payoutRequests.value;
+const filters = ref({
+  status: { value: null, matchMode: 'equals' },
 });
+
+function onPage(event: DataTablePageEvent) {
+  emit('page', event);
+}
+
+function stateFilterChange(key: string, e: SelectChangeEvent) {
+  emit('stateFilterChange', key, e.value);
+}
 
 const showModal: Ref<boolean> = ref(false);
 const dialog = ref();
 const payoutId: Ref<number> = ref(0);
-const downloadingPdf = ref<boolean>(false);
+const downloadingPdf = ref(false);
 
 const viewPayoutRequest = (id: number) => {
   showModal.value = true;
@@ -124,31 +167,4 @@ const downloadPdf = async (id: number) => {
   window.location.href = getPayoutPdfSrc(result);
   downloadingPdf.value = false;
 };
-
-onMounted(async () => {
-  await loadPayoutRequests();
-});
-
-async function loadPayoutRequests(skip = 0) {
-  isLoading.value = true;
-  const response: PaginatedBasePayoutRequestResponse = await payoutStore.fetchPayouts(rows.value, skip, props.state);
-  if (response) {
-    payoutRequests.value = response.records;
-    totalRecords.value = response._pagination.count || 0;
-  }
-  isLoading.value = false;
-}
-
-async function onPage(event: DataTablePageEvent) {
-  await loadPayoutRequests(event.first);
-}
-
-watch(
-  () => payoutStore.getUpdatedAt,
-  () => {
-    void loadPayoutRequests();
-  },
-);
 </script>
-
-<style scoped lang="scss"></style>

--- a/apps/dashboard/src/modules/financial/components/payout/PayoutTableYear.vue
+++ b/apps/dashboard/src/modules/financial/components/payout/PayoutTableYear.vue
@@ -1,0 +1,83 @@
+<template>
+  <IconField icon-position="left">
+    <InputIcon class="pi pi-search" />
+    <InputText
+      v-model="search"
+      :placeholder="t('common.id')"
+      @focusout="searchById"
+      @keyup.enter="searchById"
+      @submit="searchById"
+    />
+  </IconField>
+  <Tabs v-model:value="year" class="w-full">
+    <TabList>
+      <Tab v-for="y in years" :key="y" :value="y.toString()">{{ y }}</Tab>
+    </TabList>
+  </Tabs>
+  <PayoutTable
+    :is-loading="isLoading"
+    :payouts="records"
+    :rows="rows"
+    :total-records="totalRecords"
+    @page="onPage"
+    @state-filter-change="setFilter"
+  />
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { type BasePayoutRequestResponse, PayoutRequestStatusRequestStateEnum } from '@gewis/sudosos-client';
+import { watch } from 'vue';
+import { usePayoutStore } from '@/stores/payout.store';
+import { useTransferTableYear } from '@/composables/transferTableYear';
+import PayoutTable from '@/modules/financial/components/payout/PayoutTable.vue';
+
+const { t } = useI18n();
+const payoutStore = usePayoutStore();
+
+async function fetchPayouts({
+  page,
+  rows,
+  filters,
+  fiscalStart,
+  fiscalEnd,
+}: {
+  year: number;
+  page: number;
+  rows: number;
+  filters: { state?: PayoutRequestStatusRequestStateEnum };
+  fiscalStart: string;
+  fiscalEnd: string;
+}) {
+  return payoutStore.fetchPayouts(rows, page, {
+    status: filters.state,
+    fromDate: fiscalStart,
+    tillDate: fiscalEnd,
+  });
+}
+
+async function fetchSinglePayout(id: number) {
+  return payoutStore.fetchPayout(id);
+}
+
+const { year, years, search, rows, isLoading, records, totalRecords, onPage, setFilter, reload, searchById } =
+  useTransferTableYear<BasePayoutRequestResponse, { state?: PayoutRequestStatusRequestStateEnum }>(
+    fetchPayouts,
+    fetchSinglePayout,
+    {
+      initialFilters: { state: undefined },
+      defaultRows: 10,
+      syncQueryParams: {
+        serializeFilters: (f) => ({ state: f.state }),
+        deserializeFilters: (q) => ({
+          state: typeof q.state === 'string' ? (q.state as PayoutRequestStatusRequestStateEnum) : undefined,
+        }),
+      },
+    },
+  );
+
+watch(
+  () => payoutStore.getUpdatedAt,
+  () => void reload(),
+);
+</script>

--- a/apps/dashboard/src/modules/financial/components/write-offs/WriteOffTable.vue
+++ b/apps/dashboard/src/modules/financial/components/write-offs/WriteOffTable.vue
@@ -13,15 +13,6 @@
       :value="writeOffs"
       @page="onPage"
     >
-      <template #header>
-        <div class="flex flex-row align-items-center justify-content-between">
-          <IconField icon-position="left">
-            <InputIcon class="pi pi-search" />
-            <InputText v-model="idQuery" :placeholder="t('common.id')" @focusout="searchId" @keyup.enter="searchId" />
-          </IconField>
-          <Button class="ml-2" icon="pi pi-plus" :label="t('common.create')" @click="showDialog = true" />
-        </div>
-      </template>
       <Column field="id" :header="t('common.id')">
         <template #body="slotProps">
           <Skeleton v-if="isLoading" class="w-6 my-1 h-1rem surface-300" />
@@ -81,18 +72,6 @@
     >
       {{ t('modules.financial.write-offs.delete.not-possible') }}
     </Dialog>
-
-    <FormDialog
-      v-model="showDialog"
-      :confirm="true"
-      :form="form"
-      :header="t('modules.financial.write-offs.create')"
-      :is-editable="true"
-    >
-      <template #form="slotProps">
-        <WriteOffCreateForm :form="slotProps.form" @submit:success="showDialog = false" />
-      </template>
-    </FormDialog>
   </div>
 </template>
 
@@ -107,11 +86,7 @@ import { useI18n } from 'vue-i18n';
 import { addListenerOnDialogueOverlay } from '@sudosos/sudosos-frontend-common';
 import { useToast } from 'primevue/usetoast';
 import type { DataTablePageEvent } from 'primevue/datatable';
-import FormDialog from '@/components/FormDialog.vue';
-import WriteOffCreateForm from '@/modules/financial/components/write-offs/forms/WriteOffCreateForm.vue';
 import { formatDateFromString, formatPrice } from '@/utils/formatterUtils';
-import { schemaToForm } from '@/utils/formUtils';
-import { createWriteOffSchema } from '@/utils/validation-schema';
 import { getWriteOffPdfSrc } from '@/utils/urlUtils';
 import { useWriteOffStore } from '@/stores/writeoff.store';
 
@@ -128,7 +103,7 @@ withDefaults(
   },
 );
 
-const emit = defineEmits(['page', 'single']);
+const emit = defineEmits(['page']);
 
 const { t } = useI18n();
 const writeOffStore = useWriteOffStore();
@@ -140,18 +115,10 @@ const showWarning = () => {
   showWarningModal.value = true;
 };
 
-const showDialog = ref(false);
-const form = schemaToForm(createWriteOffSchema);
-
-const idQuery = ref('');
 const downloadingPdf = ref(false);
 
 function onPage(event: DataTablePageEvent) {
   emit('page', event);
-}
-
-function searchId() {
-  emit('single', parseInt(idQuery.value));
 }
 
 const getName = (writeOff: WriteOffResponse) => {

--- a/apps/dashboard/src/modules/financial/components/write-offs/WriteOffTableYear.vue
+++ b/apps/dashboard/src/modules/financial/components/write-offs/WriteOffTableYear.vue
@@ -1,4 +1,14 @@
 <template>
+  <IconField icon-position="left">
+    <InputIcon class="pi pi-search" />
+    <InputText
+      v-model="search"
+      :placeholder="t('common.id')"
+      @focusout="searchById"
+      @keyup.enter="searchById"
+      @submit="searchById"
+    />
+  </IconField>
   <Tabs v-model:value="year" class="w-full">
     <TabList>
       <Tab v-for="y in years" :key="y" :value="y.toString()">{{ y }}</Tab>
@@ -10,41 +20,42 @@
     :total-records="totalRecords"
     :write-offs="records"
     @page="onPage"
-    @single="onSingle"
   />
 </template>
 
 <script setup lang="ts">
 import type { WriteOffResponse } from '@gewis/sudosos-client';
-import { useFiscalYear } from '@/composables/fiscalYear';
+import { useI18n } from 'vue-i18n';
 import { useWriteOffStore } from '@/stores/writeoff.store';
-import { useDataTableYear } from '@/composables/dataTableYear';
-import type { DataTableFetchParams, DataTableFetchResult } from '@/utils/pagination';
 import WriteOffTable from '@/modules/financial/components/write-offs/WriteOffTable.vue';
-const { getFiscalYearList, getFiscalYearRange } = useFiscalYear();
-const years = getFiscalYearList();
+import { useTransferTableYear } from '@/composables/transferTableYear';
 const writeOffStore = useWriteOffStore();
+const { t } = useI18n();
+const { year, years, search, rows, isLoading, records, totalRecords, onPage, searchById } = useTransferTableYear<
+  WriteOffResponse,
+  Record<string, unknown>
+>(fetchWriteOffs, fetchSingleWriteOff, {
+  defaultRows: 10,
+  syncQueryParams: true,
+});
 
 async function fetchWriteOffs({
-  year,
   page,
   rows,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- rquired for type inference
-  filters,
-}: DataTableFetchParams<Record<string, unknown>>): Promise<DataTableFetchResult<WriteOffResponse>> {
-  const { start, end } = getFiscalYearRange(year);
-  return await writeOffStore.fetchWriteOffs(rows, page, start, end);
+  fiscalStart,
+  fiscalEnd,
+}: {
+  year: number;
+  page: number;
+  rows: number;
+  filters: Record<string, unknown>;
+  fiscalStart: string;
+  fiscalEnd: string;
+}) {
+  return await writeOffStore.fetchWriteOffs(rows, page, fiscalStart, fiscalEnd);
 }
 
 function fetchSingleWriteOff(id: number) {
   return writeOffStore.fetchWriteOff(id);
 }
-
-const { year, rows, isLoading, records, totalRecords, onPage, onSingle } = useDataTableYear<
-  WriteOffResponse,
-  Record<string, unknown>
->(fetchWriteOffs, fetchSingleWriteOff, {
-  yearList: years,
-  defaultYear: years[0]!,
-});
 </script>

--- a/apps/dashboard/src/modules/financial/views/payouts/PayoutsView.vue
+++ b/apps/dashboard/src/modules/financial/views/payouts/PayoutsView.vue
@@ -11,18 +11,7 @@
             @click="showDialog = true"
           />
         </template>
-        <Tabs class="w-full" :value="states[0]!">
-          <TabList>
-            <Tab v-for="state in states" :key="state" :value="state">
-              {{ state }}
-            </Tab>
-          </TabList>
-          <TabPanels>
-            <TabPanel v-for="state in states" :key="state" :value="state">
-              <PayoutTable :state="state" />
-            </TabPanel>
-          </TabPanels>
-        </Tabs>
+        <PayoutTableYear />
       </CardComponent>
     </div>
     <FormDialog v-model="showDialog" :form="form" :header="t('modules.financial.payout.create')" :is-editable="true">
@@ -34,26 +23,17 @@
 </template>
 
 <script setup lang="ts">
-import { PayoutRequestStatusRequestStateEnum } from '@gewis/sudosos-client';
 import { type Ref, ref } from 'vue';
-import Button from 'primevue/button';
 import { useI18n } from 'vue-i18n';
-import PayoutTable from '@/modules/financial/components/payout/PayoutTable.vue';
 import { schemaToForm } from '@/utils/formUtils';
 import { createPayoutSchema } from '@/utils/validation-schema';
 import FormDialog from '@/components/FormDialog.vue';
 import PayoutCreateForm from '@/modules/financial/components/payout/forms/PayoutCreateForm.vue';
 import CardComponent from '@/components/CardComponent.vue';
 import PageContainer from '@/layout/PageContainer.vue';
+import PayoutTableYear from '@/modules/financial/components/payout/PayoutTableYear.vue';
 
 const { t } = useI18n();
-
-const states = [
-  PayoutRequestStatusRequestStateEnum.Created,
-  PayoutRequestStatusRequestStateEnum.Approved,
-  PayoutRequestStatusRequestStateEnum.Denied,
-  PayoutRequestStatusRequestStateEnum.Cancelled,
-];
 
 const showDialog: Ref<boolean> = ref(false);
 const form = schemaToForm(createPayoutSchema);

--- a/apps/dashboard/src/modules/financial/views/write-offs/WriteOffsView.vue
+++ b/apps/dashboard/src/modules/financial/views/write-offs/WriteOffsView.vue
@@ -5,20 +5,42 @@
         <WriteOffUserOverview />
       </CardComponent>
       <CardComponent class="w-full" :header="t('modules.financial.write-offs.table.header')">
+        <template #topAction>
+          <Button icon="pi pi-plus" :label="t('common.create')" @click="showDialog = true" />
+        </template>
         <WriteOffTableYear />
+        <FormDialog
+          v-model="showDialog"
+          :confirm="true"
+          :form="form"
+          :header="t('modules.financial.write-offs.create')"
+          :is-editable="true"
+        >
+          <template #form="slotProps">
+            <WriteOffCreateForm :form="slotProps.form" @submit:success="showDialog = false" />
+          </template>
+        </FormDialog>
       </CardComponent>
     </div>
   </PageContainer>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import CardComponent from '@/components/CardComponent.vue';
 import WriteOffUserOverview from '@/modules/financial/components/write-offs/WriteOffUserOverview.vue';
 import PageContainer from '@/layout/PageContainer.vue';
 import WriteOffTableYear from '@/modules/financial/components/write-offs/WriteOffTableYear.vue';
+import FormDialog from '@/components/FormDialog.vue';
+import WriteOffCreateForm from '@/modules/financial/components/write-offs/forms/WriteOffCreateForm.vue';
+import { schemaToForm } from '@/utils/formUtils';
+import { createWriteOffSchema } from '@/utils/validation-schema';
 
 const { t } = useI18n();
+
+const showDialog = ref(false);
+const form = schemaToForm(createWriteOffSchema);
 </script>
 
 <style scoped lang="scss"></style>

--- a/apps/dashboard/src/stores/payout.store.ts
+++ b/apps/dashboard/src/stores/payout.store.ts
@@ -1,8 +1,8 @@
-import type {
-  BasePayoutRequestResponse,
-  PaginatedBasePayoutRequestResponse,
-  PayoutRequestRequest,
-  PayoutRequestResponse,
+import {
+  type BasePayoutRequestResponse,
+  type PaginatedBasePayoutRequestResponse,
+  type PayoutRequestRequest,
+  type PayoutRequestResponse,
 } from '@gewis/sudosos-client';
 import { defineStore } from 'pinia';
 import { PayoutRequestStatusRequestStateEnum } from '@gewis/sudosos-client';
@@ -36,8 +36,13 @@ export const usePayoutStore = defineStore('payout', {
     },
   },
   actions: {
-    async fetchPayouts(take: number, skip: number, state?: string): Promise<PaginatedBasePayoutRequestResponse> {
-      return apiService.payouts.getAllPayoutRequests({ status: state, take, skip }).then((res) => {
+    async fetchPayouts(
+      take: number,
+      skip: number,
+      q: { status?: string; fromDate?: string; tillDate?: string },
+    ): Promise<PaginatedBasePayoutRequestResponse> {
+      const { status, fromDate, tillDate } = q;
+      return apiService.payouts.getAllPayoutRequests({ status, fromDate, tillDate, take, skip }).then((res) => {
         res.data.records.forEach((payout: BasePayoutRequestResponse) => {
           this.payouts[payout.id] = payout;
         });


### PR DESCRIPTION
Creates a `useTransferTableYear` composable that provides a single interface to mount datatables with transfer like entities. 
Adds url query params to `useDataTableYear` to easily provide filters based on id, year and state.
Moves the invoices, write-offs and payout requests modules to use this composable.
Fixes an incorrect request type in the payouts store.

## Related issues/external references
#807

## Types of changes

- New feature _(non-breaking change which adds functionality)_