### PR TITLE
Background tasks admin page under Maintainer, with live WebSocket updates

### DIFF
--- a/apps/dashboard/src/locales/en/common/common.json
+++ b/apps/dashboard/src/locales/en/common/common.json
@@ -167,6 +167,8 @@
       "users": "Users",
       "userOverview": "User Overview",
       "banners": "Banners",
+      "tasks": "Background tasks",
+      "maintainerSettings": "Maintenance",
       "socialDrinkCards": "Social drink cards",
       "invoices": "Invoices",
       "payouts": "Payouts",
@@ -274,6 +276,7 @@
     "titles": {
       "users": "Users",
       "banners": "Banners",
+      "tasks": "Background tasks",
       "maintainer": "Maintainer",
       "rbac": "RBAC",
       "login": "Login",

--- a/apps/dashboard/src/locales/en/modules/admin.json
+++ b/apps/dashboard/src/locales/en/modules/admin.json
@@ -96,6 +96,69 @@
       "websocket": {
         "title": "Websocket logs"
       },
+      "tasks": {
+        "title": "Background tasks",
+        "list": {
+          "header": "Background tasks",
+          "empty": "No tasks yet."
+        },
+        "stats": {
+          "pending": "Pending",
+          "processing": "Processing",
+          "completed": "Completed",
+          "failed": "Failed",
+          "refresh": "Refresh"
+        },
+        "filters": {
+          "status": "Status",
+          "type": "Type",
+          "typePlaceholder": "All types"
+        },
+        "columns": {
+          "id": "ID",
+          "type": "Type",
+          "status": "Status",
+          "attempts": "Attempts",
+          "createdAt": "Created",
+          "lastError": "Last error",
+          "actions": "Actions"
+        },
+        "status": {
+          "pending": "Pending",
+          "processing": "Processing",
+          "completed": "Completed",
+          "failed": "Failed"
+        },
+        "retry": "Retry",
+        "retryConfirmTitle": "Retry task",
+        "retryConfirmMessage": "Reset task {id} and try again?",
+        "live": {
+          "live": "Live",
+          "offline": "Reconnecting..."
+        },
+        "details": {
+          "title": "Task #{id}",
+          "open": "Details",
+          "general": "General",
+          "id": "ID",
+          "type": "Type",
+          "status": "Status",
+          "attempts": "Attempts",
+          "createdAt": "Created at",
+          "updatedAt": "Updated at",
+          "startedAt": "Started at",
+          "completedAt": "Completed at",
+          "availableAt": "Available at",
+          "payload": "Payload",
+          "lastError": "Last error",
+          "none": "(none)"
+        },
+        "toast": {
+          "retried": "Task queued for retry.",
+          "retryError": "Could not retry task: {error}",
+          "loadError": "Could not load tasks: {error}"
+        }
+      },
       "dashboard": {
         "title": "Dashboard",
         "empty": "Nothing to show 🎉",

--- a/apps/dashboard/src/locales/nl/common/common.json
+++ b/apps/dashboard/src/locales/nl/common/common.json
@@ -167,6 +167,8 @@
       "users": "Gebruikers",
       "userOverview": "Gebruikersoverzicht",
       "banners": "Banners",
+      "tasks": "Achtergrondtaken",
+      "maintainerSettings": "Onderhoud",
       "socialDrinkCards": "Sociale drinkkaarten",
       "invoices": "Facturen",
       "payouts": "Uitbetalingen",
@@ -274,6 +276,7 @@
     "titles": {
       "users": "Gebruikers",
       "banners": "Banners",
+      "tasks": "Achtergrondtaken",
       "maintainer": "Maintainer",
       "rbac": "RBAC",
       "login": "Inloggen",

--- a/apps/dashboard/src/locales/nl/modules/admin.json
+++ b/apps/dashboard/src/locales/nl/modules/admin.json
@@ -96,6 +96,69 @@
       "websocket": {
         "title": "Websocket logs"
       },
+      "tasks": {
+        "title": "Achtergrondtaken",
+        "list": {
+          "header": "Achtergrondtaken",
+          "empty": "Nog geen taken."
+        },
+        "stats": {
+          "pending": "In wachtrij",
+          "processing": "Bezig",
+          "completed": "Klaar",
+          "failed": "Mislukt",
+          "refresh": "Verversen"
+        },
+        "filters": {
+          "status": "Status",
+          "type": "Type",
+          "typePlaceholder": "Alle types"
+        },
+        "columns": {
+          "id": "ID",
+          "type": "Type",
+          "status": "Status",
+          "attempts": "Pogingen",
+          "createdAt": "Aangemaakt",
+          "lastError": "Laatste fout",
+          "actions": "Acties"
+        },
+        "status": {
+          "pending": "In wachtrij",
+          "processing": "Bezig",
+          "completed": "Klaar",
+          "failed": "Mislukt"
+        },
+        "retry": "Opnieuw proberen",
+        "retryConfirmTitle": "Taak opnieuw proberen",
+        "retryConfirmMessage": "Taak {id} opnieuw in de wachtrij zetten?",
+        "live": {
+          "live": "Live",
+          "offline": "Verbinding herstellen..."
+        },
+        "details": {
+          "title": "Taak #{id}",
+          "open": "Details",
+          "general": "Algemeen",
+          "id": "ID",
+          "type": "Type",
+          "status": "Status",
+          "attempts": "Pogingen",
+          "createdAt": "Aangemaakt op",
+          "updatedAt": "Bijgewerkt op",
+          "startedAt": "Gestart op",
+          "completedAt": "Klaar op",
+          "availableAt": "Beschikbaar op",
+          "payload": "Payload",
+          "lastError": "Laatste fout",
+          "none": "(geen)"
+        },
+        "toast": {
+          "retried": "Taak teruggezet in de wachtrij.",
+          "retryError": "Kon taak niet opnieuw proberen: {error}",
+          "loadError": "Kon taken niet laden: {error}"
+        }
+      },
       "dashboard": {
         "title": "Dashboard",
         "empty": "Niets te tonen 🎉",

--- a/apps/dashboard/src/locales/pl/common/common.json
+++ b/apps/dashboard/src/locales/pl/common/common.json
@@ -167,6 +167,8 @@
       "users": "Użytkownicy",
       "userOverview": "Przegląd Użytkowników",
       "banners": "Banery",
+      "tasks": "Zadania w tle",
+      "maintainerSettings": "Utrzymanie",
       "socialDrinkCards": "Karty napojów społecznościowych",
       "invoices": "Faktury",
       "payouts": "Wypłaty",
@@ -274,6 +276,7 @@
     "titles": {
       "users": "Użytkownicy",
       "banners": "Banery",
+      "tasks": "Zadania w tle",
       "maintainer": "Utrzymanie",
       "rbac": "RBAC",
       "login": "Logowanie",

--- a/apps/dashboard/src/locales/pl/modules/admin.json
+++ b/apps/dashboard/src/locales/pl/modules/admin.json
@@ -96,6 +96,69 @@
       "websocket": {
         "title": "Logi WebSocket"
       },
+      "tasks": {
+        "title": "Zadania w tle",
+        "list": {
+          "header": "Zadania w tle",
+          "empty": "Brak zadan."
+        },
+        "stats": {
+          "pending": "Oczekuje",
+          "processing": "W trakcie",
+          "completed": "Zakonczone",
+          "failed": "Nieudane",
+          "refresh": "Odswiez"
+        },
+        "filters": {
+          "status": "Status",
+          "type": "Typ",
+          "typePlaceholder": "Wszystkie typy"
+        },
+        "columns": {
+          "id": "ID",
+          "type": "Typ",
+          "status": "Status",
+          "attempts": "Proby",
+          "createdAt": "Utworzono",
+          "lastError": "Ostatni blad",
+          "actions": "Akcje"
+        },
+        "status": {
+          "pending": "Oczekuje",
+          "processing": "W trakcie",
+          "completed": "Zakonczone",
+          "failed": "Nieudane"
+        },
+        "retry": "Sprobuj ponownie",
+        "retryConfirmTitle": "Ponow zadanie",
+        "retryConfirmMessage": "Zresetowac zadanie {id} i sprobowac ponownie?",
+        "live": {
+          "live": "Na zywo",
+          "offline": "Laczenie ponowne..."
+        },
+        "details": {
+          "title": "Zadanie #{id}",
+          "open": "Szczegoly",
+          "general": "Ogolne",
+          "id": "ID",
+          "type": "Typ",
+          "status": "Status",
+          "attempts": "Proby",
+          "createdAt": "Utworzono",
+          "updatedAt": "Zaktualizowano",
+          "startedAt": "Rozpoczeto",
+          "completedAt": "Zakonczono",
+          "availableAt": "Dostepne od",
+          "payload": "Payload",
+          "lastError": "Ostatni blad",
+          "none": "(brak)"
+        },
+        "toast": {
+          "retried": "Zadanie ponownie dodano do kolejki.",
+          "retryError": "Nie udalo sie ponowic zadania: {error}",
+          "loadError": "Nie udalo sie zaladowac zadan: {error}"
+        }
+      },
       "dashboard": {
         "title": "Panel",
         "empty": "Brak danych 🎉",

--- a/apps/dashboard/src/modules/admin/navbar.ts
+++ b/apps/dashboard/src/modules/admin/navbar.ts
@@ -5,8 +5,21 @@ import { isAllowed } from '@sudosos/sudosos-frontend-common';
 export function useAdminNav() {
   const { t } = useI18n();
 
-  return computed(() =>
-    [
+  return computed(() => {
+    const maintenanceItem = {
+      label: t('common.navigation.maintainerSettings'),
+      route: '/maintainer',
+      visible: isAllowed('update', ['all'], 'Maintenance', ['*']),
+    };
+    const tasksItem = {
+      label: t('common.navigation.tasks'),
+      route: '/maintainer/tasks',
+      visible: isAllowed('get', ['all'], 'Task', ['*']),
+    };
+    const maintainerItems = [maintenanceItem, tasksItem].filter((item) => item.visible);
+    const onlyMaintainerItem = maintainerItems.length === 1 ? maintainerItems[0] : undefined;
+
+    return [
       {
         label: t('common.navigation.admin'),
         visible:
@@ -33,9 +46,11 @@ export function useAdminNav() {
       },
       {
         label: t('common.navigation.maintainer'),
-        visible: isAllowed('update', ['all'], 'Maintenance', ['*']),
-        route: '/maintainer',
+        visible: maintainerItems.length > 0,
+        // When only one sub-item is visible, collapse the dropdown into a direct
+        // route so the navbar stays compact for admins without Task perms.
+        ...(onlyMaintainerItem ? { route: onlyMaintainerItem.route } : { items: maintainerItems }),
       },
-    ].filter((item) => item.visible),
-  );
+    ].filter((item) => item.visible);
+  });
 }

--- a/apps/dashboard/src/modules/admin/routes.ts
+++ b/apps/dashboard/src/modules/admin/routes.ts
@@ -7,6 +7,7 @@ import AdminSingleUserView from '@/modules/admin/views/AdminSingleUserView.vue';
 import AdminMaintainerView from '@/modules/admin/views/AdminMaintainerView.vue';
 import AdminRBACView from '@/modules/admin/views/AdminRBACView.vue';
 import AdminDashboardView from '@/modules/admin/views/AdminDashboardView.vue';
+import MaintainerTasksView from '@/modules/admin/views/MaintainerTasksView.vue';
 
 export function adminRoutes(): RouteRecordRaw[] {
   return [
@@ -73,6 +74,16 @@ export function adminRoutes(): RouteRecordRaw[] {
             requiresAuth: true,
             isAllowed: () => isAllowed('get', ['all'], 'Role', ['*']),
             title: 'common.titles.rbac',
+          },
+        },
+        {
+          path: '/maintainer/tasks',
+          component: MaintainerTasksView,
+          name: 'tasks',
+          meta: {
+            requiresAuth: true,
+            isAllowed: () => isAllowed('get', ['all'], 'Task', ['*']),
+            title: 'common.titles.tasks',
           },
         },
       ],

--- a/apps/dashboard/src/modules/admin/views/MaintainerTasksView.vue
+++ b/apps/dashboard/src/modules/admin/views/MaintainerTasksView.vue
@@ -1,0 +1,411 @@
+<template>
+  <PageContainer>
+    <div class="flex flex-col gap-6">
+      <CardComponent :header="t('modules.admin.tasks.title')">
+        <div class="flex flex-wrap items-end gap-4">
+          <div
+            v-for="metric in metrics"
+            :key="metric.key"
+            class="flex flex-col items-start gap-1 min-w-[8rem] rounded-md border border-surface-200 dark:border-surface-700 px-4 py-3"
+          >
+            <span class="text-xs uppercase text-surface-500">
+              {{ t(`modules.admin.tasks.stats.${metric.key}`) }}
+            </span>
+            <span class="text-2xl font-semibold" :class="metric.colour">{{ metric.value }}</span>
+          </div>
+          <div class="flex items-end gap-3 ml-auto">
+            <span class="flex items-center gap-2 text-xs uppercase">
+              <span
+                aria-hidden="true"
+                :class="['inline-block w-2 h-2 rounded-full', socketLive ? 'bg-emerald-500' : 'bg-amber-500']"
+              />
+              {{ socketLive ? t('modules.admin.tasks.live.live') : t('modules.admin.tasks.live.offline') }}
+            </span>
+            <Button icon="pi pi-refresh" :label="t('modules.admin.tasks.stats.refresh')" outlined @click="refresh" />
+          </div>
+        </div>
+      </CardComponent>
+
+      <CardComponent :header="t('modules.admin.tasks.list.header')">
+        <div class="flex flex-col gap-4">
+          <div class="flex flex-wrap items-center gap-4">
+            <div class="flex flex-col gap-1">
+              <label class="text-xs uppercase text-surface-500">
+                {{ t('modules.admin.tasks.filters.status') }}
+              </label>
+              <SelectButton
+                v-model="selectedStatuses"
+                multiple
+                option-label="label"
+                option-value="value"
+                :options="statusOptions"
+                @update:model-value="onFilterChange"
+              />
+            </div>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs uppercase text-surface-500">
+                {{ t('modules.admin.tasks.filters.type') }}
+              </label>
+              <InputText
+                v-model="typeFilter"
+                :placeholder="t('modules.admin.tasks.filters.typePlaceholder')"
+                @blur="onFilterChange"
+                @keyup.enter="onFilterChange"
+              />
+            </div>
+          </div>
+
+          <DataTable
+            data-key="id"
+            lazy
+            :loading="tasksStore.loading"
+            :paginator="true"
+            :rows="rows"
+            :rows-per-page-options="[10, 25, 50, 100]"
+            :total-records="tasksStore.total"
+            :value="tasksStore.tasks"
+            @page="onPage($event)"
+          >
+            <template #empty>
+              {{ t('modules.admin.tasks.list.empty') }}
+            </template>
+            <Column field="id" :header="t('modules.admin.tasks.columns.id')" style="width: 5rem" />
+            <Column field="type" :header="t('modules.admin.tasks.columns.type')" />
+            <Column field="status" :header="t('modules.admin.tasks.columns.status')">
+              <template #body="slotProps">
+                <Tag
+                  :severity="statusSeverity(slotProps.data.status)"
+                  :value="t(`modules.admin.tasks.status.${slotProps.data.status}`)"
+                />
+              </template>
+            </Column>
+            <Column :header="t('modules.admin.tasks.columns.attempts')" style="width: 7rem">
+              <template #body="slotProps">
+                {{ `${slotProps.data.attempts} / ${slotProps.data.maxAttempts}` }}
+              </template>
+            </Column>
+            <Column field="createdAt" :header="t('modules.admin.tasks.columns.createdAt')">
+              <template #body="slotProps">
+                {{ formatDate(slotProps.data.createdAt) }}
+              </template>
+            </Column>
+            <Column field="lastError" :header="t('modules.admin.tasks.columns.lastError')">
+              <template #body="slotProps">
+                <span class="text-sm break-words" :title="slotProps.data.lastError || ''">
+                  {{ truncate(slotProps.data.lastError) }}
+                </span>
+              </template>
+            </Column>
+            <Column :header="t('modules.admin.tasks.columns.actions')" style="width: 11rem">
+              <template #body="slotProps">
+                <div class="flex gap-2">
+                  <Button
+                    :aria-label="t('modules.admin.tasks.details.open')"
+                    icon="pi pi-info-circle"
+                    outlined
+                    severity="secondary"
+                    size="small"
+                    :title="t('modules.admin.tasks.details.open')"
+                    @click="openDetails(slotProps.data)"
+                  />
+                  <Button
+                    v-if="slotProps.data.status === 'failed'"
+                    icon="pi pi-replay"
+                    :label="t('modules.admin.tasks.retry')"
+                    size="small"
+                    @click="confirmRetry(slotProps.data.id)"
+                  />
+                </div>
+              </template>
+            </Column>
+          </DataTable>
+        </div>
+      </CardComponent>
+    </div>
+
+    <ConfirmDialog group="task-retry" />
+
+    <Dialog
+      v-model:visible="detailDialogVisible"
+      :dismissable-mask="true"
+      :header="detailTask ? t('modules.admin.tasks.details.title', { id: detailTask.id }) : ''"
+      modal
+      :style="{ width: '38rem' }"
+    >
+      <div v-if="detailTask" class="flex flex-col gap-4">
+        <div class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+          <span class="text-surface-500">{{ t('modules.admin.tasks.details.id') }}</span>
+          <span>{{ detailTask.id }}</span>
+
+          <span class="text-surface-500">{{ t('modules.admin.tasks.details.type') }}</span>
+          <span>{{ detailTask.type }}</span>
+
+          <span class="text-surface-500">{{ t('modules.admin.tasks.details.status') }}</span>
+          <span>
+            <Tag
+              :severity="statusSeverity(detailTask.status)"
+              :value="t(`modules.admin.tasks.status.${detailTask.status}`)"
+            />
+          </span>
+
+          <span class="text-surface-500">{{ t('modules.admin.tasks.details.attempts') }}</span>
+          <span>{{ `${detailTask.attempts} / ${detailTask.maxAttempts}` }}</span>
+
+          <span class="text-surface-500">{{ t('modules.admin.tasks.details.createdAt') }}</span>
+          <span>{{ formatDateOrNone(detailTask.createdAt) }}</span>
+
+          <span class="text-surface-500">{{ t('modules.admin.tasks.details.updatedAt') }}</span>
+          <span>{{ formatDateOrNone(detailTask.updatedAt) }}</span>
+
+          <span class="text-surface-500">{{ t('modules.admin.tasks.details.availableAt') }}</span>
+          <span>{{ formatDateOrNone(detailTask.availableAt) }}</span>
+
+          <span class="text-surface-500">{{ t('modules.admin.tasks.details.startedAt') }}</span>
+          <span>{{ formatDateOrNone(detailTask.startedAt) }}</span>
+
+          <span class="text-surface-500">{{ t('modules.admin.tasks.details.completedAt') }}</span>
+          <span>{{ formatDateOrNone(detailTask.completedAt) }}</span>
+        </div>
+
+        <div>
+          <div class="text-xs uppercase text-surface-500 mb-1">
+            {{ t('modules.admin.tasks.details.payload') }}
+          </div>
+          <pre
+            class="rounded-md bg-surface-100 dark:bg-surface-900 p-3 text-xs whitespace-pre-wrap break-words max-h-64 overflow-auto"
+            >{{ formatPayload(detailTask.payload) }}</pre
+          >
+        </div>
+
+        <div v-if="detailTask.lastError">
+          <div class="text-xs uppercase text-surface-500 mb-1">
+            {{ t('modules.admin.tasks.details.lastError') }}
+          </div>
+          <pre
+            class="rounded-md bg-rose-100 dark:bg-rose-950 text-rose-800 dark:text-rose-200 p-3 text-xs whitespace-pre-wrap break-words"
+            >{{ detailTask.lastError }}</pre
+          >
+        </div>
+      </div>
+    </Dialog>
+  </PageContainer>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { storeToRefs } from 'pinia';
+import { useWebSocketStore } from '@sudosos/sudosos-frontend-common';
+import DataTable, { type DataTablePageEvent } from 'primevue/datatable';
+import Column from 'primevue/column';
+import Tag from 'primevue/tag';
+import Button from 'primevue/button';
+import InputText from 'primevue/inputtext';
+import SelectButton from 'primevue/selectbutton';
+import ConfirmDialog from 'primevue/confirmdialog';
+import Dialog from 'primevue/dialog';
+import { useConfirm } from 'primevue/useconfirm';
+import { useToast } from 'primevue/usetoast';
+import { AxiosError } from 'axios';
+import type { TaskResponse } from '@gewis/sudosos-client';
+import PageContainer from '@/layout/PageContainer.vue';
+import CardComponent from '@/components/CardComponent.vue';
+import { useTasksStore, type TaskStatus } from '@/stores/tasks.store';
+
+const TASK_ROOM = 'tasks:all';
+const TASK_EVENT = 'task:updated';
+
+const { t } = useI18n();
+const tasksStore = useTasksStore();
+const toast = useToast();
+const confirm = useConfirm();
+const webSocketStore = useWebSocketStore();
+const { connected: socketLive } = storeToRefs(webSocketStore);
+
+const rows = ref(25);
+const skip = ref(0);
+const selectedStatuses = ref<TaskStatus[]>([]);
+const typeFilter = ref('');
+
+const detailDialogVisible = ref(false);
+const detailTask = ref<TaskResponse | null>(null);
+
+const statusOptions = computed(() =>
+  (['pending', 'processing', 'completed', 'failed'] as TaskStatus[]).map((value) => ({
+    value,
+    label: t(`modules.admin.tasks.status.${value}`),
+  })),
+);
+
+const metrics = computed(() => [
+  { key: 'pending', value: tasksStore.stats.pending, colour: 'text-amber-600' },
+  { key: 'processing', value: tasksStore.stats.processing, colour: 'text-sky-600' },
+  { key: 'completed', value: tasksStore.stats.completed, colour: 'text-emerald-600' },
+  { key: 'failed', value: tasksStore.stats.failed, colour: 'text-rose-600' },
+]);
+
+const statusSeverity = (status: string): 'info' | 'warn' | 'success' | 'danger' | 'secondary' => {
+  switch (status) {
+    case 'pending':
+      return 'warn';
+    case 'processing':
+      return 'info';
+    case 'completed':
+      return 'success';
+    case 'failed':
+      return 'danger';
+    default:
+      return 'secondary';
+  }
+};
+
+const formatDate = (value?: string | null) => (value ? new Date(value).toLocaleString() : '');
+const formatDateOrNone = (value?: string | null) =>
+  value ? new Date(value).toLocaleString() : t('modules.admin.tasks.details.none');
+const truncate = (value?: string | null) => {
+  if (!value) return '';
+  return value.length > 80 ? `${value.slice(0, 80)}...` : value;
+};
+
+const formatPayload = (payload: string | undefined) => {
+  if (!payload) return t('modules.admin.tasks.details.none');
+  try {
+    return JSON.stringify(JSON.parse(payload), null, 2);
+  } catch {
+    return payload;
+  }
+};
+
+const buildFilters = () => ({
+  status: selectedStatuses.value.length > 0 ? selectedStatuses.value : undefined,
+  type: typeFilter.value.trim() ? typeFilter.value.trim() : undefined,
+});
+
+// Debounced stats refresh so a burst of WebSocket events doesn't pummel the API.
+let statsTimer: ReturnType<typeof setTimeout> | null = null;
+const refreshStatsDebounced = () => {
+  if (statsTimer) clearTimeout(statsTimer);
+  statsTimer = setTimeout(() => {
+    void tasksStore.fetchStats();
+  }, 250);
+};
+
+const reload = async () => {
+  try {
+    await Promise.all([
+      tasksStore.fetchTasks({ filters: buildFilters(), take: rows.value, skip: skip.value }),
+      tasksStore.fetchStats(),
+    ]);
+  } catch (err) {
+    const message = err instanceof AxiosError ? err.message : String(err);
+    toast.add({
+      severity: 'error',
+      summary: t('modules.admin.tasks.toast.loadError', { error: message }),
+      life: 4000,
+    });
+  }
+};
+
+const onPage = (event: DataTablePageEvent) => {
+  rows.value = event.rows;
+  skip.value = event.first;
+  void reload();
+};
+
+const onFilterChange = () => {
+  skip.value = 0;
+  void reload();
+};
+
+const refresh = () => {
+  void reload();
+};
+
+const passesFilters = (task: TaskResponse): boolean => {
+  const filters = buildFilters();
+  if (filters.status && !filters.status.includes(task.status as TaskStatus)) return false;
+  if (filters.type && task.type !== filters.type) return false;
+  return true;
+};
+
+const onTaskUpdated = (task: TaskResponse) => {
+  if (!detailTask.value || detailTask.value.id !== task.id) {
+    // Update the dialog if it's open on this task.
+  } else {
+    detailTask.value = task;
+  }
+  if (passesFilters(task)) {
+    tasksStore.applyUpdate(task);
+  }
+  refreshStatsDebounced();
+};
+
+const openDetails = (task: TaskResponse) => {
+  detailTask.value = task;
+  detailDialogVisible.value = true;
+};
+
+const confirmRetry = (id: number) => {
+  confirm.require({
+    group: 'task-retry',
+    header: t('modules.admin.tasks.retryConfirmTitle'),
+    message: t('modules.admin.tasks.retryConfirmMessage', { id }),
+    accept: () => {
+      void (async () => {
+        try {
+          await tasksStore.retryTask(id);
+          toast.add({
+            severity: 'success',
+            summary: t('modules.admin.tasks.toast.retried'),
+            life: 3000,
+          });
+        } catch (err) {
+          const message = err instanceof AxiosError ? err.message : String(err);
+          toast.add({
+            severity: 'error',
+            summary: t('modules.admin.tasks.toast.retryError', { error: message }),
+            life: 4000,
+          });
+        }
+      })();
+    },
+  });
+};
+
+// WebSocket subscription wiring. The socket itself is set up by the
+// `setupWebSocket` call in `beforeLoad`; here we just join the task room
+// while the view is mounted and tear down on unmount.
+const onSocketConnect = () => {
+  try {
+    webSocketStore.getSocket.emit('subscribe', TASK_ROOM);
+  } catch {
+    // socket not yet ready; the connect handler below covers reconnects.
+  }
+};
+
+onMounted(() => {
+  void reload();
+  try {
+    const socket = webSocketStore.getSocket;
+    socket.on(TASK_EVENT, onTaskUpdated);
+    socket.on('connect', onSocketConnect);
+    if (socket.connected) {
+      onSocketConnect();
+    }
+  } catch {
+    // No socket configured (e.g. SSR build); falls back to manual refresh.
+  }
+});
+
+onBeforeUnmount(() => {
+  if (statsTimer) clearTimeout(statsTimer);
+  try {
+    const socket = webSocketStore.getSocket;
+    socket.emit('unsubscribe', TASK_ROOM);
+    socket.off(TASK_EVENT, onTaskUpdated);
+    socket.off('connect', onSocketConnect);
+  } catch {
+    // socket not initialised; nothing to clean up.
+  }
+});
+</script>

--- a/apps/dashboard/src/stores/tasks.store.ts
+++ b/apps/dashboard/src/stores/tasks.store.ts
@@ -1,0 +1,73 @@
+import { defineStore } from 'pinia';
+import { type TaskResponse, type TaskStatsResponse } from '@gewis/sudosos-client';
+import apiService from '@/services/ApiService';
+
+export type TaskStatus = 'pending' | 'processing' | 'completed' | 'failed';
+
+export interface TaskFilters {
+  status?: TaskStatus[];
+  type?: string;
+}
+
+export interface FetchTasksOptions {
+  filters?: TaskFilters;
+  take?: number;
+  skip?: number;
+}
+
+export const useTasksStore = defineStore('tasks', {
+  state: () => ({
+    tasks: [] as TaskResponse[],
+    total: 0,
+    stats: { pending: 0, processing: 0, completed: 0, failed: 0 } as TaskStatsResponse,
+    loading: false,
+  }),
+  actions: {
+    async fetchTasks(options: FetchTasksOptions = {}): Promise<void> {
+      this.loading = true;
+      try {
+        const { filters = {}, take = 50, skip = 0 } = options;
+        const status = filters.status && filters.status.length > 0 ? filters.status.join(',') : undefined;
+        const resp = await apiService.tasks.listTasks({
+          take,
+          skip,
+          status,
+          type: filters.type,
+        });
+        this.tasks = resp.data.records ?? [];
+        this.total = resp.data._pagination?.count ?? this.tasks.length;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    async fetchStats(): Promise<void> {
+      const resp = await apiService.tasks.getTaskStats();
+      this.stats = resp.data;
+    },
+
+    async retryTask(id: number): Promise<TaskResponse> {
+      const resp = await apiService.tasks.retryTask({ id });
+      const updated = resp.data;
+      const idx = this.tasks.findIndex((t) => t.id === id);
+      if (idx !== -1) {
+        this.tasks.splice(idx, 1, updated);
+      }
+      return updated;
+    },
+
+    /**
+     * Merge a server-pushed task update into the visible list. If the row is
+     * already on screen we replace it in place; brand-new dispatches get
+     * prepended so admins see them appear at the top in real time.
+     */
+    applyUpdate(task: TaskResponse): void {
+      const idx = this.tasks.findIndex((t) => t.id === task.id);
+      if (idx !== -1) {
+        this.tasks.splice(idx, 1, task);
+      } else {
+        this.tasks.unshift(task);
+      }
+    },
+  },
+});

--- a/apps/dashboard/src/utils/beforeLoadUtil.ts
+++ b/apps/dashboard/src/utils/beforeLoadUtil.ts
@@ -1,5 +1,6 @@
 import {
   clearTokenInStorage,
+  getTokenFromStorage,
   populateStoresFromToken,
   setupWebSocket,
   useAuthStore,
@@ -14,7 +15,11 @@ export default async function beforeLoad() {
   initializeAuthHook();
 
   try {
-    setupWebSocket();
+    // Send the latest JWT on every socket (re)connect so the server can
+    // attach the user and authorise room subscriptions (e.g. `tasks:all`).
+    // The getter is invoked per connect attempt, so token refreshes are
+    // picked up automatically.
+    setupWebSocket({ getToken: () => getTokenFromStorage(apiService.tokenKey).token ?? null });
     await settingsStore.fetchKeys();
   } catch (e) {
     console.error(e);

--- a/lib/common/src/services/ApiService.ts
+++ b/lib/common/src/services/ApiService.ts
@@ -23,6 +23,7 @@ import {
   SellerPayoutsApi,
   WriteoffsApi,
   ServerSettingsApi,
+  TasksApi,
   UserNotificationPreferencesApi,
 } from '@gewis/sudosos-client';
 import axios, { type AxiosInstance, type AxiosResponse } from 'axios';
@@ -77,6 +78,8 @@ export class ApiService {
 
   private readonly _serverSettingsApi: ServerSettingsApi;
 
+  private readonly _tasksApi: TasksApi;
+
   private readonly _userNotificationsApi: UserNotificationPreferencesApi;
 
   private readonly _inactiveAdministrativeCostsApi: InactiveAdministrativeCostsApi;
@@ -122,6 +125,7 @@ export class ApiService {
     this._sellerPayoutsApi = new SellerPayoutsApi(withKeyConfiguration, basePath, this._axiosInstance);
     this._writeOffsApi = new WriteoffsApi(withKeyConfiguration, basePath, this._axiosInstance);
     this._serverSettingsApi = new ServerSettingsApi(withKeyConfiguration, basePath, this._axiosInstance);
+    this._tasksApi = new TasksApi(withKeyConfiguration, basePath, this._axiosInstance);
     this._userNotificationsApi = new UserNotificationPreferencesApi(
       withKeyConfiguration,
       basePath,
@@ -224,6 +228,10 @@ export class ApiService {
 
   get serverSettings(): ServerSettingsApi {
     return this._serverSettingsApi;
+  }
+
+  get tasks(): TasksApi {
+    return this._tasksApi;
   }
 
   get userNotifications(): UserNotificationPreferencesApi {


### PR DESCRIPTION
# Description

Companion to [sudosos-backend#918](https://github.com/GEWIS/sudosos-backend/pull/918) (closes [#322](https://github.com/GEWIS/sudosos-backend/issues/322)). Adds an admin-only **Background tasks** page under the Maintainer dropdown that lists, filters, retries, and inspects the new backend task queue.

## What's in this PR (commit by commit)

1. **`feat: expose TasksApi on the shared ApiService`** -- one-line plumbing in `lib/common`. The dashboard can now call `apiService.tasks.listTasks(...)`, `.retryTask(...)`, `.getTaskStats(...)`.
2. **`fix: send JWT on dashboard WebSocket connection so authenticated rooms work`** -- the dashboard's `setupWebSocket()` was called without a token, so the socket connected anonymously and any room with a policy (e.g. the new `tasks:all`) responded "Authentication required for this room." Mirrors the POS app's pattern: pass a getter that reads the JWT on every (re)connect. Latent bug; this PR is the first room that actually requires it.
3. **`feat: add background tasks admin page under maintainer`** -- the bulk of the work:
   - New `MaintainerTasksView.vue` at `/maintainer/tasks`.
   - "Maintainer" navbar entry becomes a dropdown (Maintenance + Background tasks). Collapses back to a single link when the user only has one of the perms.
   - Stats grid (pending / processing / completed / failed) backed by `/v1/tasks/stats`.
   - Paginated, filterable DataTable. Status (multi-select) and type (free-text) filters. Each row has a (i) info button that opens a Dialog with the full task: id, type, status tag, attempts, every timestamp, pretty-printed JSON payload, full last error. Failed rows additionally show a Retry button.
   - "LIVE" indicator. The view subscribes to the `tasks:all` WebSocket room on mount and listens for `task:updated` events. Rows update in place, new dispatches appear at the top, stats refresh via a 250ms debounce -- no polling.
   - New `tasks.store.ts` (Pinia) -- `fetchTasks`, `fetchStats`, `retryTask`, `applyUpdate` (merges socket events into the visible list).
   - i18n keys in en/nl/pl: `common.navigation.tasks`, `common.navigation.maintainerSettings`, `common.titles.tasks`, and the full `modules.admin.tasks.*` block (stats labels, filter labels, column headers, status labels, retry confirmation, detail dialog, toasts, live/offline indicator).

## Related issues/external references

Closes the frontend half of GEWIS/sudosos-backend#322. Depends on the backend PR shipping first (the dashboard talks to `/v1/tasks`).

## Types of changes

- New feature _(non-breaking change which adds functionality)_

## Screenshots

A screenshot of the page with the detail dialog open is in the backend PR's E2E thread. I'll drop one inline here once the local dev server's back up -- in the meantime, the structure is straightforward and matches the description above. (Apologies, my preview server got recycled between testing and PR creation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)