### PR TITLE
fix: derive TOS router guard from computed acceptedToS

### DIFF
--- a/apps/dashboard/src/router/index.ts
+++ b/apps/dashboard/src/router/index.ts
@@ -105,9 +105,7 @@ const router = createRouter({
 router.beforeEach((to, from, next) => {
   const authStore = useAuthStore();
 
-  const hasTOSAccepted = () => {
-    return authStore.acceptedToS || authStore.user?.acceptedToS;
-  };
+  const hasTOSAccepted = () => authStore.acceptedToS;
 
   const isAuth = isAuthenticated();
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
The guard compared authStore.user?.tosRequired && authStore.acceptedToS against the status strings, which yields a boolean/undefined for non-required users instead of a TermsOfServiceStatus. Use authStore .acceptedToS directly: it is computed against the current TOS version, carried in the JWT, and already encodes ACCEPTED / NOT_ACCEPTED / NOT_REQUIRED for the logged-in user.

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_