### PR TITLE
Pay for an anonymous cart with a Stripe terminal

### DIFF
--- a/apps/point-of-sale/src/components/Cart/CartActionsComponent.vue
+++ b/apps/point-of-sale/src/components/Cart/CartActionsComponent.vue
@@ -28,7 +28,11 @@
     @denied="onAgeVerificationDenied"
     @update:show="showAgeVerification = $event"
   />
-  <div class="flex justify-between w-full">
+  <TerminalPaymentModal :show="showTerminalPayment" @update:show="showTerminalPayment = $event" />
+  <!-- gap-6 matches the spacing justify-between happens to leave between the
+       fixed-width Checkout button and the logout icon on an authenticated POS,
+       so borrel mode (where Checkout is full width) looks identical. -->
+  <div class="flex justify-between gap-6 w-full">
     <Button
       class="border-0 checkout font-medium rounder text-3xl"
       :class="{ countdown: checkingOut, disabled: !enabled, borrelMode }"
@@ -37,6 +41,15 @@
       {{ checkoutText }}
     </Button>
     <div class="flex justify-center items-center">
+      <Button
+        v-if="borrelMode"
+        aria-label="Pay with card terminal"
+        class="terminal p-3 text-2xl text-white flex items-center justify-center w-16 h-16"
+        :disabled="!terminalEnabled"
+        @click="payWithTerminal"
+      >
+        <i class="pi pi-credit-card" style="font-size: 2rem" />
+      </Button>
       <Button
         v-if="!borrelMode"
         class="p-3 text-2xl text-white flex items-center justify-center w-16 h-16"
@@ -57,6 +70,7 @@ import { useCheckoutTimer } from '@/composables/useCheckoutTimer';
 import { playAudio, Sound } from '@/utils/audioUtil';
 import AprilFoolsComponent from '@/components/AprilFoolsComponent.vue';
 import AgeVerificationComponent from '@/components/AgeVerificationComponent.vue';
+import TerminalPaymentModal from '@/components/Cart/TerminalPaymentModal.vue';
 
 const emit = defineEmits(['selectCreator']);
 
@@ -85,6 +99,21 @@ const checkoutText = computed(() => {
 const enabled = computed(() => {
   return cartItems.length > 0 && buyer.value;
 });
+
+const showTerminalPayment = ref(false);
+
+// Terminal payments are anonymous for now: the sale is booked in the name of
+// the POS itself. That only makes sense in borrel mode, where "select no one"
+// exists -- an authenticated POS always has someone to charge, so the button
+// is not rendered there at all (see the v-if in the template).
+const terminalEnabled = computed(() => cartItems.length > 0 && !buyer.value);
+
+const payWithTerminal = () => {
+  if (!terminalEnabled.value) return;
+
+  stopCheckout();
+  showTerminalPayment.value = true;
+};
 
 const logout = async () => {
   stopCheckout();
@@ -153,6 +182,13 @@ const checkout = () => {
 .clear {
   color: white;
   background-color: red;
+}
+
+.terminal:disabled {
+  background-color: grey;
+  border-color: grey;
+  opacity: 1;
+  cursor: not-allowed;
 }
 
 .checkout {

--- a/apps/point-of-sale/src/components/Cart/TerminalPaymentModal.vue
+++ b/apps/point-of-sale/src/components/Cart/TerminalPaymentModal.vue
@@ -1,0 +1,193 @@
+<template>
+  <Dialog
+    v-model:visible="visible"
+    class="w-120"
+    :closable="false"
+    :dismissable-mask="false"
+    :draggable="false"
+    header="Card payment"
+    modal
+    :pt="{
+      header: () => ({ class: ['dialog-header'] }),
+    }"
+  >
+    <div class="flex flex-col items-center gap-6 py-4">
+      <!-- `idle` is covered too: the dialog is visible for a frame before
+           startPayment flips the phase, and an empty dialog looks broken. -->
+      <template v-if="phase === 'idle' || phase === 'preparing'">
+        <ProgressSpinner />
+        <p class="text-xl text-center">Sending to the terminal...</p>
+      </template>
+
+      <template v-else-if="phase === 'waiting'">
+        <ProgressSpinner />
+        <p class="text-2xl font-semibold text-center">{{ formattedAmount }}</p>
+        <p class="text-xl text-center">Let the customer tap or insert their card on the terminal.</p>
+        <p class="text-center opacity-70">
+          The terminal keeps asking until the payment goes through. Press Cancel to give up on this payment.
+        </p>
+      </template>
+
+      <template v-else-if="phase === 'cancelled'">
+        <Message :icon="undefined" severity="warn">The payment was cancelled. Nothing has been charged.</Message>
+      </template>
+
+      <template v-else-if="phase === 'error'">
+        <Message :icon="undefined" severity="error">{{ errorMessage }}</Message>
+      </template>
+    </div>
+
+    <template #footer>
+      <div class="flex justify-center w-full">
+        <Button v-if="phase === 'waiting'" class="terminal-cancel text-xl px-6 py-3" @click="onCancel"> Cancel </Button>
+        <Button
+          v-else-if="phase === 'cancelled' || phase === 'error'"
+          class="terminal-close text-xl px-6 py-3"
+          @click="close"
+        >
+          Close
+        </Button>
+      </div>
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, onUnmounted, ref, watch } from 'vue';
+import { useToast } from 'primevue/usetoast';
+import { useCartStore } from '@/stores/cart.store';
+import { useTerminalPaymentStore } from '@/stores/terminalPayment.store';
+import { usePosToken } from '@/composables/usePosToken';
+import { playAudio, Sound } from '@/utils/audioUtil';
+import { formatDineroObjectToString } from '@/utils/FormatUtils';
+
+const props = defineProps<{
+  show: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:show', value: boolean): void;
+  (e: 'paid'): void;
+}>();
+
+const toast = useToast();
+const cartStore = useCartStore();
+const terminalPaymentStore = useTerminalPaymentStore();
+const { getPosUserIdFromToken } = usePosToken();
+
+const visible = computed({
+  get: () => props.show,
+  set: (value) => emit('update:show', value),
+});
+
+const phase = computed(() => terminalPaymentStore.phase);
+const errorMessage = computed(() => terminalPaymentStore.errorMessage);
+
+/**
+ * The amount is frozen when the payment is created, so show what the backend
+ * recorded rather than the live cart total.
+ */
+const formattedAmount = computed(() => {
+  const amount = terminalPaymentStore.getPayment?.amount;
+  return amount ? formatDineroObjectToString(amount) : '';
+});
+
+/** Guards against the watcher firing twice for one opening. */
+const starting = ref(false);
+
+const close = () => {
+  terminalPaymentStore.reset();
+  visible.value = false;
+};
+
+const start = async () => {
+  const posUserId = getPosUserIdFromToken();
+  if (posUserId === null) {
+    toast.add({
+      severity: 'error',
+      summary: 'This device is not linked to a point of sale, so it cannot take card payments.',
+      life: 5000,
+    });
+    visible.value = false;
+    return;
+  }
+
+  // Both `from` and `createdBy` are the POS itself. Beyond matching the
+  // anonymous-sale semantics, it keeps the payment inside the POS token's
+  // `own` RBAC relation for its whole lifecycle -- including after a
+  // cancellation detaches the temporary transaction.
+  const request = cartStore.buildTransactionRequest(posUserId, posUserId);
+  if (!request) {
+    toast.add({ severity: 'error', summary: 'Could not build the transaction for this cart.', life: 5000 });
+    visible.value = false;
+    return;
+  }
+
+  try {
+    await terminalPaymentStore.startPayment(request);
+  } catch {
+    // startPayment has already put the reason on the store for display.
+  }
+};
+
+watch(
+  visible,
+  async (isVisible) => {
+    if (!isVisible || starting.value) return;
+
+    starting.value = true;
+    try {
+      await start();
+    } finally {
+      starting.value = false;
+    }
+  },
+  { immediate: true },
+);
+
+watch(
+  () => terminalPaymentStore.phase,
+  async (newPhase) => {
+    if (newPhase !== 'paid') return;
+
+    playAudio(Sound.CASHOUT);
+    await cartStore.clearAfterCheckout();
+    terminalPaymentStore.reset();
+    visible.value = false;
+    emit('paid');
+  },
+);
+
+const onCancel = async () => {
+  try {
+    await terminalPaymentStore.cancelPayment();
+  } catch {
+    toast.add({
+      severity: 'error',
+      summary: 'Could not cancel the payment. Check the terminal before trying again.',
+      life: 5000,
+    });
+  }
+};
+
+onUnmounted(() => {
+  terminalPaymentStore.stopPolling();
+});
+</script>
+
+<style scoped lang="scss">
+.dialog-header {
+  background: var(--accent-color) !important;
+  color: white !important;
+}
+
+.terminal-cancel {
+  background-color: red;
+  color: white;
+  border: none;
+}
+
+.terminal-close {
+  border: none;
+}
+</style>

--- a/apps/point-of-sale/src/components/Cart/TransactionHistory/TransactionHistoryRowComponent.vue
+++ b/apps/point-of-sale/src/components/Cart/TransactionHistory/TransactionHistoryRowComponent.vue
@@ -11,7 +11,10 @@
       </div>
       <div v-if="settings.isBorrelmode">
         <div class="fs-6 mt-1">
-          Transaction for {{ transaction.from.firstName }} by {{ transaction.createdBy?.firstName }}
+          <template v-if="isTerminalPayment">Transaction paid with Terminal</template>
+          <template v-else>
+            Transaction for {{ transaction.from.firstName }} by {{ transaction.createdBy?.firstName }}
+          </template>
         </div>
       </div>
       <!-- Here, we attach animation related functions to the corresponding Vue transition hooks-->
@@ -43,9 +46,11 @@ import { BaseTransactionResponse, TransactionResponse } from '@gewis/sudosos-cli
 import { formatDateFromString, formatTimeFromString, formatDineroObjectToString } from '@/utils/FormatUtils';
 import { userApiService } from '@/services/ApiService';
 import { useSettingStore } from '@/stores/settings.store';
+import { usePosToken } from '@/composables/usePosToken';
 
 const emit = defineEmits(['update:open']);
 const settings = useSettingStore();
+const { getPosUserIdFromToken } = usePosToken();
 
 const props = defineProps({
   transaction: {
@@ -56,6 +61,17 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+});
+
+/**
+ * A transaction booked in the name of the POS itself is an anonymous terminal
+ * payment, so naming a buyer and a creator is meaningless -- both are the POS.
+ * BaseUserResponse carries no user type, so the POS's own user id is what we
+ * have to compare against.
+ */
+const isTerminalPayment = computed(() => {
+  const posUserId = getPosUserIdFromToken();
+  return posUserId !== null && props.transaction.from.id === posUserId;
 });
 
 // To store the extra infromation in

--- a/apps/point-of-sale/src/composables/usePosToken.ts
+++ b/apps/point-of-sale/src/composables/usePosToken.ts
@@ -54,6 +54,23 @@ export function usePosToken() {
     }
   };
 
+  /**
+   * The id of the POINT_OF_SALE-type user this token was minted for. Anonymous
+   * terminal payments are booked in the name of that user, so this is the
+   * `from` of such a transaction.
+   */
+  const getPosUserIdFromToken = (): number | null => {
+    const token = getPosToken();
+    if (!token) return null;
+
+    try {
+      const decoded = jwtDecode<{ user: { id: number } }>(token);
+      return decoded.user.id || null;
+    } catch {
+      return null;
+    }
+  };
+
   return {
     hasPosToken,
     setPosToken,
@@ -61,5 +78,6 @@ export function usePosToken() {
     getPosToken,
     refreshPosToken,
     getPosIdFromToken,
+    getPosUserIdFromToken,
   };
 }

--- a/apps/point-of-sale/src/stores/cart.store.ts
+++ b/apps/point-of-sale/src/stores/cart.store.ts
@@ -136,9 +136,17 @@ export const useCartStore = defineStore('cart', {
       const nonAlcoholic = this.products.filter((p) => p.product.alcoholPercentage === 0);
       this.products.splice(0, this.products.length, ...nonAlcoholic);
     },
-    async checkout(): Promise<void> {
+    /**
+     * Assemble the current cart into a TransactionRequest. Shared by the
+     * balance-debit checkout (`from` is the selected buyer) and by anonymous
+     * terminal payments (`from` is the POS's own user).
+     *
+     * Returns null when there is no POS loaded, since the request cannot be
+     * built without a point of sale revision.
+     */
+    buildTransactionRequest(fromUserId: number, createdById: number): TransactionRequest | null {
       const pos = usePointOfSaleStore().getPos;
-      if (!this.buyer || !pos) return;
+      if (!pos) return null;
 
       const containerSubTransactionsRows: {
         [key: string]: { container: ContainerResponse; row: SubTransactionRowRequest[] };
@@ -185,11 +193,9 @@ export const useCartStore = defineStore('cart', {
         },
       );
 
-      const authStore = useAuthStore();
-
-      const request: TransactionRequest = {
-        createdBy: this.createdBy ? this.createdBy.id : authStore.getUser?.id,
-        from: this.buyer.id,
+      return {
+        createdBy: createdById,
+        from: fromUserId,
         pointOfSale: {
           id: pos.id,
           revision: pos.revision,
@@ -201,8 +207,22 @@ export const useCartStore = defineStore('cart', {
           amount: this.getTotalPrice,
         },
       };
+    },
+    async checkout(): Promise<void> {
+      const authStore = useAuthStore();
+      const createdById = this.createdBy ? this.createdBy.id : authStore.getUser?.id;
+      if (!this.buyer || createdById === undefined) return;
+
+      const request = this.buildTransactionRequest(this.buyer.id, createdById);
+      if (!request) return;
 
       await userApiService.transaction.createTransaction({ transactionRequest: request });
+      await this.clearAfterCheckout();
+    },
+    /**
+     * Reset cart state after a completed sale, regardless of how it was paid.
+     */
+    async clearAfterCheckout(): Promise<void> {
       this.products.length = 0;
       await this.setBuyer(this.lockedIn);
       this.createdBy = null;

--- a/apps/point-of-sale/src/stores/terminalPayment.store.ts
+++ b/apps/point-of-sale/src/stores/terminalPayment.store.ts
@@ -1,0 +1,240 @@
+import { defineStore } from 'pinia';
+import type { StripePaymentTerminalResponse, TerminalPaymentResponse, TransactionRequest } from '@gewis/sudosos-client';
+import { posApiService } from '@/services/ApiService';
+
+/**
+ * Mirror of the backend's TerminalPaymentState. The generated client types
+ * `state` as a bare string, so the union lives here.
+ */
+export type TerminalPaymentState = 'created' | 'processing' | 'paid' | 'cancelled';
+
+/**
+ * What the cashier is currently looking at: `preparing` while we resolve the
+ * reader and register the payment, `waiting` once the reader is asking for a
+ * card and we're polling for the result, then `paid` or `cancelled` once
+ * Stripe or the cashier settles it.
+ */
+export type TerminalPaymentPhase = 'idle' | 'preparing' | 'waiting' | 'paid' | 'cancelled' | 'error';
+
+/**
+ * Thrown when we cannot decide which reader to send a payment to. A POS is
+ * assumed to have exactly one reader next to it; anything else needs a human.
+ */
+export class TerminalUnavailableError extends Error {
+  public readonly reason: 'none' | 'multiple';
+
+  public constructor(public readonly available: number) {
+    super(`Expected exactly one available Stripe terminal, found ${available}`);
+    this.name = 'TerminalUnavailableError';
+    this.reason = available === 0 ? 'none' : 'multiple';
+  }
+}
+
+const POLL_INTERVAL_MS = 2000;
+
+/**
+ * How many consecutive polling errors we tolerate before giving up. Polling
+ * rides on the network, so a single blip should not kill an in-flight payment.
+ */
+const MAX_POLL_FAILURES = 3;
+
+const isSettled = (state: string): boolean => state === 'paid' || state === 'cancelled';
+
+const statusOf = (error: unknown): number | undefined =>
+  (error as { response?: { status?: number } })?.response?.status;
+
+/**
+ * Turn a failed terminal lookup into something a cashier can act on.
+ *
+ * The whole /terminal-payments router only exists when the server has Stripe
+ * configured, so a 404 here means card payments are switched off rather than
+ * that a reader is missing.
+ */
+const describeTerminalLookupFailure = (error: unknown): string => {
+  if (error instanceof TerminalUnavailableError) {
+    return error.reason === 'none'
+      ? 'No payment terminal is available. Is it switched on and connected?'
+      : `Found ${error.available} available payment terminals, so it is unclear which one to use. Ask a bar manager to sort this out.`;
+  }
+
+  if (statusOf(error) === 404) {
+    return 'Card payments are not enabled on this SudoSOS server.';
+  }
+
+  return 'Could not reach the payment terminal.';
+};
+
+interface TerminalPaymentState_ {
+  payment: TerminalPaymentResponse | null;
+  phase: TerminalPaymentPhase;
+  errorMessage: string | null;
+}
+
+/**
+ * Timer handle for the polling loop. Deliberately module-level rather than
+ * store state: it is not data, and keeping it out of the store stops Pinia
+ * devtools from trying to serialise a timer.
+ */
+let pollTimer: ReturnType<typeof setTimeout> | undefined;
+
+export const useTerminalPaymentStore = defineStore('terminalPayment', {
+  state: (): TerminalPaymentState_ => ({
+    payment: null,
+    phase: 'idle',
+    errorMessage: null,
+  }),
+  getters: {
+    getPayment(): TerminalPaymentResponse | null {
+      return this.payment;
+    },
+    /** The backend's state for the active payment, narrowed from the client's bare string. */
+    paymentState(): TerminalPaymentState | null {
+      return (this.payment?.state as TerminalPaymentState | undefined) ?? null;
+    },
+    /** True while the reader is busy and the cashier can only wait or cancel. */
+    isWaiting(): boolean {
+      return this.phase === 'waiting';
+    },
+  },
+  actions: {
+    /**
+     * Resolve the single available Stripe reader for this POS.
+     * @throws {TerminalUnavailableError} when there is not exactly one.
+     */
+    async resolveTerminal(): Promise<StripePaymentTerminalResponse> {
+      const terminals = await posApiService.terminalPayments.getStripeTerminals().then((res) => res.data);
+      const available = terminals.filter((t) => t.available);
+
+      if (available.length !== 1) {
+        throw new TerminalUnavailableError(available.length);
+      }
+
+      return available[0]!;
+    },
+
+    /**
+     * Register the transaction as a terminal payment and push it to the reader.
+     *
+     * The reader is resolved *before* the payment is created: creating one
+     * leaves a temporary transaction and a Stripe payment intent behind, so we
+     * only do that once we know there is somewhere to send it. If handing the
+     * payment to the reader then fails, the just-created payment is cancelled
+     * so it does not linger in `created` forever.
+     */
+    async startPayment(request: TransactionRequest): Promise<void> {
+      this.stopPolling();
+      this.payment = null;
+      this.errorMessage = null;
+      this.phase = 'preparing';
+
+      let terminal: StripePaymentTerminalResponse;
+      try {
+        terminal = await this.resolveTerminal();
+      } catch (error) {
+        this.phase = 'error';
+        this.errorMessage = describeTerminalLookupFailure(error);
+        throw error;
+      }
+
+      const payment = await posApiService.terminalPayments
+        .createTerminalPayment({ createTerminalPaymentRequest: { transaction: request } })
+        .then((res) => res.data);
+      this.payment = payment;
+
+      try {
+        await posApiService.terminalPayments.startTerminalPayment({
+          id: payment.id,
+          processTerminalPaymentRequest: { stripeTerminalId: terminal.id },
+        });
+      } catch (error) {
+        // Nothing is on the reader, so drop the payment rather than leaving it
+        // dangling and holding a Stripe payment intent open.
+        await this.cancelPayment().catch(() => undefined);
+        this.phase = 'error';
+        this.errorMessage = 'The payment terminal did not accept the payment. Please try again.';
+        throw error;
+      }
+
+      this.phase = 'waiting';
+      this.scheduleNextPoll();
+    },
+
+    /**
+     * Poll the payment until it is paid or cancelled. Scheduled with setTimeout
+     * rather than setInterval so a slow response cannot overlap requests.
+     */
+    scheduleNextPoll(failures = 0): void {
+      pollTimer = setTimeout(() => {
+        void this.pollOnce(failures);
+      }, POLL_INTERVAL_MS);
+    },
+
+    async pollOnce(failures: number): Promise<void> {
+      // A cancel or unmount may have landed while the timer was pending.
+      if (this.phase !== 'waiting' || !this.payment) return;
+
+      try {
+        const payment = await posApiService.terminalPayments
+          .getSingleTerminalPayment({ id: this.payment.id })
+          .then((res) => res.data);
+
+        if (this.phase !== 'waiting') return;
+        this.payment = payment;
+
+        if (isSettled(payment.state)) {
+          this.phase = payment.state === 'paid' ? 'paid' : 'cancelled';
+          return;
+        }
+
+        this.scheduleNextPoll();
+      } catch (error) {
+        if (this.phase !== 'waiting') return;
+
+        // Once Stripe cancels a payment the backend detaches its temporary
+        // transaction, which can drop our POS token out of the `own` relation
+        // and make this endpoint 403. Treat losing access, or the payment
+        // disappearing, as a cancellation rather than retrying forever.
+        const status = statusOf(error);
+        if (status === 403 || status === 404) {
+          this.phase = 'cancelled';
+          return;
+        }
+
+        if (failures + 1 >= MAX_POLL_FAILURES) {
+          this.phase = 'error';
+          this.errorMessage =
+            'Lost contact with SudoSOS while waiting for the payment. Check the terminal before retrying.';
+          return;
+        }
+
+        this.scheduleNextPoll(failures + 1);
+      }
+    },
+
+    stopPolling(): void {
+      clearTimeout(pollTimer);
+      pollTimer = undefined;
+    },
+
+    /**
+     * Cancel the in-flight payment, both on the reader and in SudoSOS. Safe to
+     * call when there is nothing to cancel.
+     */
+    async cancelPayment(): Promise<void> {
+      this.stopPolling();
+      const payment = this.payment;
+      if (!payment) return;
+
+      const response = await posApiService.terminalPayments.cancelTerminalPayment({ id: payment.id });
+      this.payment = response.data;
+      this.phase = 'cancelled';
+    },
+
+    reset(): void {
+      this.stopPolling();
+      this.payment = null;
+      this.phase = 'idle';
+      this.errorMessage = null;
+    },
+  },
+});

--- a/lib/common/src/services/ApiService.ts
+++ b/lib/common/src/services/ApiService.ts
@@ -15,6 +15,7 @@ import {
   RbacApi,
   RootApi,
   StripeApi,
+  TerminalPaymentsApi,
   TransactionsApi,
   TransfersApi,
   UsersApi,
@@ -67,6 +68,8 @@ export class ApiService {
   private readonly _vatGroupsApi: VatGroupsApi;
 
   private readonly _stripeApi: StripeApi;
+
+  private readonly _terminalPaymentsApi: TerminalPaymentsApi;
 
   private readonly _rbacApi: RbacApi;
 
@@ -121,6 +124,7 @@ export class ApiService {
     this._transfersApi = new TransfersApi(withKeyConfiguration, basePath, this._axiosInstance);
     this._vatGroupsApi = new VatGroupsApi(withKeyConfiguration, basePath, this._axiosInstance);
     this._stripeApi = new StripeApi(withKeyConfiguration, basePath, this._axiosInstance);
+    this._terminalPaymentsApi = new TerminalPaymentsApi(withKeyConfiguration, basePath, this._axiosInstance);
     this._rbacApi = new RbacApi(withKeyConfiguration, basePath, this._axiosInstance);
     this._sellerPayoutsApi = new SellerPayoutsApi(withKeyConfiguration, basePath, this._axiosInstance);
     this._writeOffsApi = new WriteoffsApi(withKeyConfiguration, basePath, this._axiosInstance);
@@ -204,6 +208,10 @@ export class ApiService {
 
   get stripe(): StripeApi {
     return this._stripeApi;
+  }
+
+  get terminalPayments(): TerminalPaymentsApi {
+    return this._terminalPaymentsApi;
   }
 
   get rbac(): RbacApi {


### PR DESCRIPTION
# Description

Lets someone without a SudoSOS account pay for a cart straight on a Stripe
Terminal reader. This is the frontend half of GEWIS/sudosos-backend#967, which
added anonymous terminal payments in time for the Introduction Week.

In borrel mode a card button shows up next to the checkout button. Pressing it
registers the cart as a `TerminalPayment`, hands it to the reader, and polls
until the payment settles. On success the backend books the transaction and the
cart clears the same way it does after any other sale.

Only borrel mode gets the button. An anonymous sale needs a cart with nobody
selected, and "select no one" only exists on an unauthenticated POS. On an
authenticated POS there is always someone to charge, so the button would sit
there greyed out forever.

A few decisions that need explaining.

`from` and `createdBy` are both the POS user. That matches how an anonymous sale
is supposed to work, and it keeps the payment inside the POS token's `own` RBAC
relation for its whole life. Cancelling detaches the temporary transaction, so
with the cashier as `createdBy` there would be nothing left for `getRelation` to
match on, and polling would start coming back 403.

The reader is resolved before the payment gets created. Creating a
`TerminalPayment` also creates a temporary transaction and a Stripe payment
intent, and there is no reason to do that when there is nowhere to send it. If
handing the payment to the reader fails after that, we cancel it rather than
leave it stuck in `created`.

Everything goes through `posApiService`. Only the Point of Sale role has
`TerminalPayment` permissions, so a cashier's own token gets rejected.

Polling chains `setTimeout` instead of using `setInterval`, so a slow response
can't overlap the next request. It tolerates a few network errors in a row
before giving up, and treats 403/404 as a cancellation.

Servers without Stripe configured don't mount `/v1/terminal-payments` at all, so
that 404 is reported as "card payments are not enabled on this SudoSOS server"
rather than blamed on a missing reader.

## Client bump

Pins `@gewis/sudosos-client` to `0.0.0-develop.c63332b` (backend `c63332bf`),
the first build that exposes `TerminalPaymentsApi`. Nothing tagged has it yet,
so this wants moving to a real version once one is cut.

The bump drags two unrelated fixes along with it:

- axios goes to an exact `1.18.1` to match the client's own dependency. The old
  `^1.14.0` range resolved a second copy of axios, which matters because
  `lib/common` builds the axios instance and hands it to client classes typed
  against a different one. The repo already pins this way.
- `AcceptTosRequest` now requires a `version`, so `updateUserToSAccepted` takes
  it and the dashboard passes the version it rendered. The backend only accepts
  the current version, so sending what the user actually saw is better than
  re-fetching at submit time.

## Verification

Against a local backend and POS dev server: button visibility per mode, the
enablement matrix with its styling and tooltips, and the real 404 from a
backend without Stripe keys.

The happy path and the failure cases used a stub at the XHR boundary, so
everything above the network call is the real store, modal and component:

- `terminals -> create -> process -> poll -> paid`, checking the outgoing
  `TransactionRequest` field by field, the reader being picked automatically,
  then the cashout sound and a cleared cart
- zero and multiple available readers, which give different messages and create
  no payment at all
- cashier cancel: sends `DELETE`, keeps the cart, stops polling without leaking
  a timer
- a Stripe-side cancel picked up by polling, and a 403 mid-poll
- `process` failing, which cancels the payment it just created

Two gaps.

There are no unit tests, because this repo has no test runner at all and adding
the first one inside a payment feature felt like the wrong place for it. The
store is shaped to be testable whenever that happens.

Nothing has run against real Stripe yet. That needs test credentials plus either
hardware or Stripe's simulated reader. Worth doing before anyone trusts this at
a live bar; `cli/stripe-terminal.ts` in the backend is the place to start.

## Related issues/external references

Frontend side of GEWIS/sudosos-backend#967, which implements scenario 1 of
GEWIS/sudosos-backend#852.

## Types of changes

- New feature _(non-breaking change which adds functionality)_
