### PR TITLE
Deduplicate dashboard mutation table components

### DIFF
--- a/apps/dashboard/src/components/mutations/MutationsBalance.vue
+++ b/apps/dashboard/src/components/mutations/MutationsBalance.vue
@@ -1,164 +1,52 @@
 <template>
-  <DataTable
-    lazy
+  <MutationsTable
+    ref="tableRef"
+    :fetch-page="fetchPage"
     :paginator="paginator"
-    :rows="rows"
-    :rows-per-page-options="[5, 10, 25, 50, 100]"
-    :total-records="totalRecords"
-    :value="mutations"
-    @page="onPage($event)"
+    :preload="preload"
+    :rows-amount="rowsAmount"
+    show-edited-icon
   >
-    <Column field="moment" :header="t('components.mutations.when')">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-6" />
-      </template>
-      <template v-else #body="mutation">
-        <span class="hidden sm:block">
+    <template #columns="{ isLoading }">
+      <Column field="createdBy" :header="t(`components.mutations.${isMd ? 'createdBy' : 'By'}`)">
+        <template v-if="isLoading" #body>
+          <Skeleton class="h-1rem my-1 surface-300 w-6" />
+        </template>
+        <template v-else #body="mutation">
           {{
-            mutation.data.moment.toLocaleDateString(locale, {
-              dateStyle: 'full',
-            })
+            mutation.data.createdBy && currentUserId !== mutation.data.createdBy?.id
+              ? isMd
+                ? `${mutation.data.createdBy.firstName} ${mutation.data.createdBy.lastName}`
+                : mutation.data.createdBy.firstName
+              : t('components.mutations.you')
           }}
-          <i
-            v-if="mutation.data.editedAt !== undefined"
-            v-tooltip="
-              t('components.mutations.editedOn', {
-                date: mutation.data.editedAt.toLocaleDateString('nl-NL', {
-                  dateStyle: 'short',
-                }),
-              })
-            "
-            class="pi pi-pencil ml-2"
-          />
-        </span>
-        <span class="sm:hidden whitespace-nowrap">
-          {{
-            mutation.data.moment.toLocaleDateString('nl-NL', {
-              dateStyle: 'short',
-            })
-          }}
-          <i
-            v-if="mutation.data.editedAt !== undefined"
-            v-tooltip="
-              t('components.mutations.editedOn', {
-                date: mutation.data.editedAt.toLocaleDateString('nl-NL', {
-                  dateStyle: 'short',
-                }),
-              })
-            "
-            class="pi pi-pencil ml-2"
-          />
-        </span>
-      </template>
-    </Column>
+        </template>
+      </Column>
 
-    <Column field="createdBy" :header="t(`components.mutations.${isMd ? 'createdBy' : 'By'}`)">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-6" />
-      </template>
-
-      <template v-else #body="mutation">
-        {{
-          mutation.data.createdBy && currentUserId !== mutation.data.createdBy?.id
-            ? isMd
-              ? `${mutation.data.createdBy.firstName} ${mutation.data.createdBy.lastName}`
-              : mutation.data.createdBy.firstName
-            : t('components.mutations.you')
-        }}
-      </template>
-    </Column>
-
-    <Column class="hidden sm:block" field="mutationPOS" :header="t('components.mutations.pos')">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-6" />
-      </template>
-      <template v-else #body="mutation">
-        {{ mutation.data.pos || '-' }}
-      </template>
-    </Column>
-
-    <Column field="change" :header="t('components.mutations.amount')">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-3" />
-      </template>
-      <template v-else #body="mutation">
-        <!-- Deposits, Invoices, Waived fines all get green -->
-        <div v-if="isIncreasingTransfer(mutation.data.type)" class="font-bold" style="color: #198754">
-          {{ formatPrice((mutation.data as FinancialMutation).amount) }}
-        </div>
-
-        <!-- Fines and inactive costs get red -->
-        <div
-          v-else-if="
-            isFine(mutation.data.type) || mutation.data.type === FinancialMutationType.INACTIVE_ADMINISTRATIVE_COST
-          "
-          class="font-bold"
-          style="color: #d40000"
-        >
-          {{ formatPrice((mutation.data as FinancialMutation).amount, true) }}
-        </div>
-
-        <!-- Other transactions stay black -->
-        <div v-else>
-          {{ formatPrice((mutation.data as FinancialMutation).amount, true) }}
-        </div>
-      </template>
-    </Column>
-
-    <Column field="" style="width: 10%">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-3" />
-      </template>
-      <template v-else #body="mutation">
-        <i
-          class="cursor-pointer pi pi-info-circle"
-          @click="() => openModal(mutation.data.id, mutation.data.type, mutation.data.inactiveCostId)"
-        />
-      </template>
-    </Column>
-  </DataTable>
-  <ModalMutation
-    v-if="
-      openedMutationId &&
-      openedMutationType !== undefined &&
-      openedMutationType !== FinancialMutationType.INACTIVE_ADMINISTRATIVE_COST
-    "
-    :id="openedMutationId"
-    v-model:visible="isModalVisible"
-    :type="openedMutationType"
-    @deleted="refresh"
-  />
-  <ModalInactive
-    v-if="openedInactiveCostId"
-    :id="openedInactiveCostId"
-    @close="handleInactiveClose"
-    @delete="handleInactiveDelete"
-  />
+      <Column class="hidden sm:block" field="mutationPOS" :header="t('components.mutations.pos')">
+        <template v-if="isLoading" #body>
+          <Skeleton class="h-1rem my-1 surface-300 w-6" />
+        </template>
+        <template v-else #body="mutation">
+          {{ mutation.data.pos || '-' }}
+        </template>
+      </Column>
+    </template>
+  </MutationsTable>
 </template>
 <script lang="ts" setup>
-import DataTable, { type DataTablePageEvent } from 'primevue/datatable';
-import Column from 'primevue/column';
-import { computed, onMounted, type Ref, ref } from 'vue';
+import { computed, ref } from 'vue';
 import { useUserStore } from '@sudosos/sudosos-frontend-common';
 import type { PaginatedFinancialMutationResponse } from '@gewis/sudosos-client';
 import { useI18n } from 'vue-i18n';
-import { formatPrice } from '@/utils/formatterUtils';
-import {
-  type FinancialMutation,
-  FinancialMutationType,
-  parseFinancialMutations,
-  isIncreasingTransfer,
-  isFine,
-} from '@/utils/mutationUtils';
-import ModalMutation from '@/components/mutations/mutationmodal/ModalMutation.vue';
-import ModalInactive from '@/components/mutations/mutationmodal/ModalInactive.vue';
+import { parseFinancialMutations } from '@/utils/mutationUtils';
 import { useSizeBreakpoints } from '@/composables/sizeBreakpoints';
-import { usePrefetchMutationDetails } from '@/composables/preloadMutationDetails';
+import MutationsTable from '@/components/mutations/MutationsTable.vue';
 
-const { t, locale } = useI18n();
+const { t } = useI18n();
 const userStore = useUserStore();
 const { isMd } = useSizeBreakpoints();
-const pl = usePrefetchMutationDetails().preload;
+const currentUserId = computed(() => userStore.current.user?.id);
 
 const props = defineProps<{
   getMutations: (take: number, skip: number) => Promise<PaginatedFinancialMutationResponse | undefined>;
@@ -167,64 +55,17 @@ const props = defineProps<{
   preload?: boolean;
 }>();
 
-const rows: Ref<number> = ref(props.rowsAmount || 10);
-const mutations = ref<FinancialMutation[]>(new Array(rows.value));
-const totalRecords = ref<number>(0);
-const isLoading: Ref<boolean> = ref(true);
-const currentUserId = computed(() => userStore.current.user?.id);
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+const tableRef = ref<InstanceType<typeof MutationsTable> | null>(null);
 
-// Expose the refresh method
-async function refresh() {
-  isLoading.value = true;
-  const newTransactions = await props.getMutations(rows.value, 0);
-  if (!newTransactions) {
-    isLoading.value = false;
-    return;
-  }
-  mutations.value = parseFinancialMutations(newTransactions);
-  totalRecords.value = newTransactions._pagination.count || 0;
-  isLoading.value = false;
+async function fetchPage(take: number, skip: number) {
+  const result = await props.getMutations(take, skip);
+  if (!result) return undefined;
+  return { rows: parseFinancialMutations(result), total: result._pagination.count || 0 };
 }
 
-onMounted(async () => {
-  await refresh().then(() => {
-    if (props.preload) void pl(mutations.value);
-  });
-});
-
-async function onPage(event: DataTablePageEvent) {
-  const newTransactions = await props.getMutations(event.rows, event.first);
-  if (!newTransactions) {
-    isLoading.value = true;
-    return;
-  }
-  mutations.value = parseFinancialMutations(newTransactions);
-}
-
-const openedMutationId = ref<number>();
-const openedMutationType = ref<FinancialMutationType>();
-const openedInactiveCostId = ref<number>();
-const isModalVisible = ref<boolean>(false);
-
-function openModal(id: number, type: FinancialMutationType, inactiveCostId?: number) {
-  if (type === FinancialMutationType.INACTIVE_ADMINISTRATIVE_COST) {
-    if (inactiveCostId !== undefined && inactiveCostId !== null) {
-      openedInactiveCostId.value = inactiveCostId;
-    }
-  } else {
-    openedMutationId.value = id;
-    openedMutationType.value = type;
-    isModalVisible.value = true;
-  }
-}
-
-function handleInactiveClose() {
-  openedInactiveCostId.value = undefined;
-}
-
-function handleInactiveDelete() {
-  openedInactiveCostId.value = undefined;
-  void refresh();
+function refresh() {
+  return tableRef.value?.refresh();
 }
 
 defineExpose({ refresh });

--- a/apps/dashboard/src/components/mutations/MutationsPOS.vue
+++ b/apps/dashboard/src/components/mutations/MutationsPOS.vue
@@ -1,107 +1,34 @@
 <template>
-  <DataTable
-    lazy
-    :paginator="paginator"
-    :rows="rows"
-    :rows-per-page-options="[5, 10, 25, 50, 100]"
-    :total-records="totalRecords"
-    :value="mutations"
-    @page="onPage($event)"
-  >
-    <Column field="moment" :header="t('components.mutations.when')">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-6" />
-      </template>
-      <template v-else #body="mutation">
-        <span class="hidden sm:block">{{
-          mutation.data.moment.toLocaleDateString(locale, {
-            dateStyle: 'full',
-          })
-        }}</span>
-        <span class="sm:hidden"
-          >{{
-            mutation.data.moment.toLocaleDateString('nl-NL', {
-              dateStyle: 'short',
-            })
-          }}
-        </span>
-      </template>
-    </Column>
+  <MutationsTable ref="tableRef" :fetch-page="fetchPage" :paginator="paginator" :rows-amount="rowsAmount">
+    <template #columns="{ isLoading }">
+      <Column field="createdBy" :header="t('components.mutations.createdBy')">
+        <template v-if="isLoading" #body>
+          <Skeleton class="h-1rem my-1 surface-300 w-6" />
+        </template>
+        <template v-else #body="mutation">
+          {{ mutation.data.createdBy?.firstName + ' ' + mutation.data.createdBy?.lastName }}
+        </template>
+      </Column>
 
-    <Column field="createdBy" :header="t('components.mutations.createdBy')">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-6" />
-      </template>
-      <template v-else #body="mutation">
-        {{ mutation.data.createdBy?.firstName + ' ' + mutation.data.createdBy?.lastName }}
-      </template>
-    </Column>
-
-    <Column field="createdFor" :header="t('components.mutations.createdFor')">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-6" />
-      </template>
-      <template v-else #body="mutation">
-        {{ mutation.data.from?.firstName + ' ' + mutation.data.from?.lastName }}
-      </template>
-    </Column>
-
-    <Column field="change" :header="t('components.mutations.amount')">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-3" />
-      </template>
-      <template v-else #body="mutation">
-        <!-- Deposits, Invoices, Waived fines all get green -->
-        <div v-if="isIncreasingTransfer(mutation.data.type)" class="font-bold" style="color: #198754">
-          {{ formatPrice((mutation.data as FinancialMutation).amount) }}
-        </div>
-
-        <!-- Fines get green -->
-        <div v-else-if="isFine(mutation.data.type)" class="font-bold" style="color: #d40000">
-          {{ formatPrice((mutation.data as FinancialMutation).amount, true) }}
-        </div>
-
-        <!-- Other transactions stay black -->
-        <div v-else>
-          {{ formatPrice((mutation.data as FinancialMutation).amount, true) }}
-        </div>
-      </template>
-    </Column>
-
-    <Column field="" style="width: 10%">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-3" />
-      </template>
-      <template v-else #body="mutation">
-        <i class="cursor-pointer pi pi-info-circle" @click="() => openModal(mutation.data.id, mutation.data.type)" />
-      </template>
-    </Column>
-  </DataTable>
-  <ModalMutation
-    v-if="openedMutationId && openedMutationType"
-    :id="openedMutationId"
-    v-model:visible="isModalVisible"
-    :type="openedMutationType"
-    @deleted="refresh"
-  />
+      <Column field="createdFor" :header="t('components.mutations.createdFor')">
+        <template v-if="isLoading" #body>
+          <Skeleton class="h-1rem my-1 surface-300 w-6" />
+        </template>
+        <template v-else #body="mutation">
+          {{ mutation.data.from?.firstName + ' ' + mutation.data.from?.lastName }}
+        </template>
+      </Column>
+    </template>
+  </MutationsTable>
 </template>
 <script lang="ts" setup>
-import DataTable, { type DataTablePageEvent } from 'primevue/datatable';
-import Column from 'primevue/column';
-import { onMounted, type Ref, ref } from 'vue';
-import { type PaginatedBaseTransactionResponse } from '@gewis/sudosos-client';
+import { ref } from 'vue';
+import type { PaginatedBaseTransactionResponse } from '@gewis/sudosos-client';
 import { useI18n } from 'vue-i18n';
-import { formatPrice } from '@/utils/formatterUtils';
-import {
-  type FinancialMutation,
-  FinancialMutationType,
-  parseFinancialMutations,
-  isIncreasingTransfer,
-  isFine,
-} from '@/utils/mutationUtils';
-import ModalMutation from '@/components/mutations/mutationmodal/ModalMutation.vue';
+import { parseFinancialMutations } from '@/utils/mutationUtils';
+import MutationsTable from '@/components/mutations/MutationsTable.vue';
 
-const { t, locale } = useI18n();
+const { t } = useI18n();
 
 const props = defineProps<{
   getMutations: (take: number, skip: number) => Promise<PaginatedBaseTransactionResponse | undefined>;
@@ -109,48 +36,17 @@ const props = defineProps<{
   rowsAmount?: number;
 }>();
 
-const mutations = ref<FinancialMutation[]>(new Array(10));
-const totalRecords = ref<number>(0);
-const isLoading: Ref<boolean> = ref(true);
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+const tableRef = ref<InstanceType<typeof MutationsTable> | null>(null);
 
-const rows: Ref<number> = ref(props.rowsAmount || 10);
-onMounted(async () => {
-  const initialMutations = await props.getMutations(rows.value, 0);
-  if (!initialMutations) return;
-  mutations.value = parseFinancialMutations(initialMutations);
-  totalRecords.value = initialMutations._pagination.count || 0;
-  isLoading.value = false;
-});
-
-async function onPage(event: DataTablePageEvent) {
-  const newTransactions = await props.getMutations(event.rows, event.first);
-  if (!newTransactions) {
-    isLoading.value = true;
-    return;
-  }
-  mutations.value = parseFinancialMutations(newTransactions);
+async function fetchPage(take: number, skip: number) {
+  const result = await props.getMutations(take, skip);
+  if (!result) return undefined;
+  return { rows: parseFinancialMutations(result), total: result._pagination.count || 0 };
 }
 
-async function refresh() {
-  isLoading.value = true;
-  const newTransactions = await props.getMutations(rows.value, 0);
-  if (!newTransactions) {
-    isLoading.value = false;
-    return;
-  }
-  mutations.value = parseFinancialMutations(newTransactions);
-  totalRecords.value = newTransactions._pagination.count || 0;
-  isLoading.value = false;
-}
-
-const openedMutationId = ref<number>();
-const openedMutationType = ref<FinancialMutationType>();
-const isModalVisible = ref<boolean>(false);
-
-function openModal(id: number, type: FinancialMutationType) {
-  openedMutationId.value = id;
-  openedMutationType.value = type;
-  isModalVisible.value = true;
+function refresh() {
+  return tableRef.value?.refresh();
 }
 
 defineExpose({ refresh });

--- a/apps/dashboard/src/components/mutations/MutationsSeller.vue
+++ b/apps/dashboard/src/components/mutations/MutationsSeller.vue
@@ -1,153 +1,52 @@
 <template>
-  <DataTable
-    data-key="id"
-    lazy
-    :paginator="paginator"
-    :rows="rows"
-    :rows-per-page-options="[5, 10, 25, 50, 100]"
-    :total-records="totalRecords"
-    :value="mutations"
-    @page="onPage($event)"
-  >
-    <Column field="moment" :header="t('components.mutations.when')">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-6" />
-      </template>
-      <template v-else #body="mutation">
-        <span class="hidden sm:block">{{
-          mutation.data.moment.toLocaleDateString(locale, {
-            dateStyle: 'full',
-          })
-        }}</span>
-        <span class="sm:hidden"
-          >{{
-            mutation.data.moment.toLocaleDateString('nl-NL', {
-              dateStyle: 'short',
-            })
-          }}
-        </span>
-      </template>
-    </Column>
+  <MutationsTable ref="tableRef" data-key="id" :fetch-page="fetchPage" :paginator="paginator" :rows-amount="rowsAmount">
+    <template #columns="{ isLoading }">
+      <Column field="createdFor" :header="t('components.mutations.createdFor')">
+        <template v-if="isLoading" #body>
+          <Skeleton class="h-1rem my-1 surface-300 w-6" />
+        </template>
+        <template v-else #body="mutation">
+          {{ mutation.data.from?.firstName }}
+        </template>
+      </Column>
 
-    <Column field="createdFor" :header="t('components.mutations.createdFor')">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-6" />
-      </template>
-      <template v-else #body="mutation">
-        {{ mutation.data.from?.firstName }}
-      </template>
-    </Column>
-
-    <Column class="hidden sm:block" field="mutationPOS" :header="t('components.mutations.pos')">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-6" />
-      </template>
-      <template v-else #body="mutation">
-        {{ mutation.data.pos }}
-      </template>
-    </Column>
-
-    <Column field="change" :header="t('components.mutations.amount')">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-3" />
-      </template>
-      <template v-else #body="mutation">
-        <!-- Deposits, Invoices, Waived fines all get green -->
-        <div v-if="isIncreasingTransfer(mutation.data.type)" class="font-bold" style="color: #198754">
-          {{ formatPrice((mutation.data as FinancialMutation).amount) }}
-        </div>
-
-        <!-- Fines get green -->
-        <div v-else-if="isFine(mutation.data.type)" class="font-bold" style="color: #d40000">
-          {{ formatPrice((mutation.data as FinancialMutation).amount, true) }}
-        </div>
-
-        <!-- Other transactions stay black -->
-        <div v-else>
-          {{ formatPrice((mutation.data as FinancialMutation).amount, true) }}
-        </div>
-      </template>
-    </Column>
-
-    <Column field="" style="width: 10%">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-3" />
-      </template>
-      <template v-else #body="mutation">
-        <i class="cursor-pointer pi pi-info-circle" @click="() => openModal(mutation.data.id, mutation.data.type)" />
-      </template>
-    </Column>
-  </DataTable>
-  <ModalMutation
-    v-if="openedMutationId && openedMutationType"
-    :id="openedMutationId"
-    v-model:visible="isModalVisible"
-    :type="openedMutationType"
-    @deleted="refresh"
-  />
+      <Column class="hidden sm:block" field="mutationPOS" :header="t('components.mutations.pos')">
+        <template v-if="isLoading" #body>
+          <Skeleton class="h-1rem my-1 surface-300 w-6" />
+        </template>
+        <template v-else #body="mutation">
+          {{ mutation.data.pos }}
+        </template>
+      </Column>
+    </template>
+  </MutationsTable>
 </template>
 <script lang="ts" setup>
-import DataTable, { type DataTablePageEvent } from 'primevue/datatable';
-import Column from 'primevue/column';
-import { onMounted, type Ref, ref } from 'vue';
+import { ref } from 'vue';
 import type { PaginatedBaseTransactionResponse } from '@gewis/sudosos-client';
 import { useI18n } from 'vue-i18n';
-import ModalMutation from '@/components/mutations/mutationmodal/ModalMutation.vue';
-import { formatPrice } from '@/utils/formatterUtils';
-import { FinancialMutationType, isIncreasingTransfer, isFine } from '@/utils/mutationUtils';
-import { type FinancialMutation, parseFinancialMutations } from '@/utils/mutationUtils';
+import { parseFinancialMutations } from '@/utils/mutationUtils';
+import MutationsTable from '@/components/mutations/MutationsTable.vue';
 
-const { t, locale } = useI18n();
+const { t } = useI18n();
 
 const props = defineProps<{
   getMutations: (take: number, skip: number) => Promise<PaginatedBaseTransactionResponse | undefined>;
-  filterVisible?: boolean;
   paginator?: boolean;
   rowsAmount?: number;
 }>();
 
-const mutations = ref<FinancialMutation[]>(new Array(10));
-const totalRecords = ref<number>(0);
-const isLoading: Ref<boolean> = ref(true);
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+const tableRef = ref<InstanceType<typeof MutationsTable> | null>(null);
 
-const rows: Ref<number> = ref(props.rowsAmount || 10);
-onMounted(async () => {
-  const initialMutations = await props.getMutations(rows.value, 0);
-  if (!initialMutations) return;
-  mutations.value = parseFinancialMutations(initialMutations);
-  totalRecords.value = initialMutations._pagination.count || 0;
-  isLoading.value = false;
-});
-
-async function onPage(event: DataTablePageEvent) {
-  const newTransactions = await props.getMutations(event.rows, event.first);
-  if (!newTransactions) {
-    isLoading.value = true;
-    return;
-  }
-  mutations.value = parseFinancialMutations(newTransactions);
+async function fetchPage(take: number, skip: number) {
+  const result = await props.getMutations(take, skip);
+  if (!result) return undefined;
+  return { rows: parseFinancialMutations(result), total: result._pagination.count || 0 };
 }
 
-async function refresh() {
-  isLoading.value = true;
-  const newTransactions = await props.getMutations(rows.value, 0);
-  if (!newTransactions) {
-    isLoading.value = false;
-    return;
-  }
-  mutations.value = parseFinancialMutations(newTransactions);
-  totalRecords.value = newTransactions._pagination.count || 0;
-  isLoading.value = false;
-}
-
-const openedMutationId = ref<number>();
-const openedMutationType = ref<FinancialMutationType>();
-const isModalVisible = ref<boolean>(false);
-
-function openModal(id: number, type: FinancialMutationType) {
-  openedMutationId.value = id;
-  openedMutationType.value = type;
-  isModalVisible.value = true;
+function refresh() {
+  return tableRef.value?.refresh();
 }
 
 defineExpose({ refresh });

--- a/apps/dashboard/src/components/mutations/MutationsTable.vue
+++ b/apps/dashboard/src/components/mutations/MutationsTable.vue
@@ -1,0 +1,195 @@
+<template>
+  <DataTable
+    :data-key="dataKey"
+    lazy
+    :paginator="paginator"
+    :rows="rows"
+    :rows-per-page-options="[5, 10, 25, 50, 100]"
+    :total-records="totalRecords"
+    :value="mutations"
+    @page="onPage($event)"
+  >
+    <Column field="moment" :header="t('components.mutations.when')">
+      <template v-if="isLoading" #body>
+        <Skeleton class="h-1rem my-1 surface-300 w-6" />
+      </template>
+      <template v-else #body="mutation">
+        <span class="hidden sm:block">
+          {{
+            mutation.data.moment.toLocaleDateString(locale, {
+              dateStyle: 'full',
+            })
+          }}
+          <i
+            v-if="showEditedIcon && mutation.data.editedAt !== undefined"
+            v-tooltip="
+              t('components.mutations.editedOn', {
+                date: mutation.data.editedAt.toLocaleDateString('nl-NL', {
+                  dateStyle: 'short',
+                }),
+              })
+            "
+            class="pi pi-pencil ml-2"
+          />
+        </span>
+        <span class="sm:hidden whitespace-nowrap">
+          {{
+            mutation.data.moment.toLocaleDateString('nl-NL', {
+              dateStyle: 'short',
+            })
+          }}
+          <i
+            v-if="showEditedIcon && mutation.data.editedAt !== undefined"
+            v-tooltip="
+              t('components.mutations.editedOn', {
+                date: mutation.data.editedAt.toLocaleDateString('nl-NL', {
+                  dateStyle: 'short',
+                }),
+              })
+            "
+            class="pi pi-pencil ml-2"
+          />
+        </span>
+      </template>
+    </Column>
+
+    <slot :is-loading="isLoading" name="columns" />
+
+    <Column field="amount" :header="t('components.mutations.amount')">
+      <template v-if="isLoading" #body>
+        <Skeleton class="h-1rem my-1 surface-300 w-3" />
+      </template>
+      <template v-else #body="mutation">
+        <!-- Deposits, Invoices, Waived fines all get green -->
+        <div v-if="isIncreasingTransfer(mutation.data.type)" class="font-bold" style="color: #198754">
+          {{ formatPrice((mutation.data as FinancialMutation).amount) }}
+        </div>
+
+        <!-- Fines and inactive costs get red -->
+        <div
+          v-else-if="
+            isFine(mutation.data.type) || mutation.data.type === FinancialMutationType.INACTIVE_ADMINISTRATIVE_COST
+          "
+          class="font-bold"
+          style="color: #d40000"
+        >
+          {{ formatPrice((mutation.data as FinancialMutation).amount, true) }}
+        </div>
+
+        <!-- Other transactions stay black -->
+        <div v-else>
+          {{ formatPrice((mutation.data as FinancialMutation).amount, true) }}
+        </div>
+      </template>
+    </Column>
+
+    <Column field="" style="width: 10%">
+      <template v-if="isLoading" #body>
+        <Skeleton class="h-1rem my-1 surface-300 w-3" />
+      </template>
+      <template v-else #body="mutation">
+        <i
+          class="cursor-pointer pi pi-info-circle"
+          @click="() => openModal(mutation.data.id, mutation.data.type, mutation.data.inactiveCostId)"
+        />
+      </template>
+    </Column>
+  </DataTable>
+  <ModalMutation
+    v-if="
+      openedMutationId &&
+      openedMutationType !== undefined &&
+      openedMutationType !== FinancialMutationType.INACTIVE_ADMINISTRATIVE_COST
+    "
+    :id="openedMutationId"
+    v-model:visible="isModalVisible"
+    :type="openedMutationType"
+    @deleted="refresh"
+  />
+  <ModalInactive
+    v-if="openedInactiveCostId"
+    :id="openedInactiveCostId"
+    @close="handleInactiveClose"
+    @delete="handleInactiveDelete"
+  />
+</template>
+<script lang="ts" setup>
+import type { DataTablePageEvent } from 'primevue/datatable';
+import { onMounted, type Ref, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { formatPrice } from '@/utils/formatterUtils';
+import { type FinancialMutation, FinancialMutationType, isIncreasingTransfer, isFine } from '@/utils/mutationUtils';
+import ModalMutation from '@/components/mutations/mutationmodal/ModalMutation.vue';
+import ModalInactive from '@/components/mutations/mutationmodal/ModalInactive.vue';
+import { usePrefetchMutationDetails } from '@/composables/preloadMutationDetails';
+
+const { t, locale } = useI18n();
+const pl = usePrefetchMutationDetails().preload;
+
+const props = defineProps<{
+  /** Fetches and parses one page of rows, normalizing whatever response shape the caller's API returns. */
+  fetchPage: (take: number, skip: number) => Promise<{ rows: FinancialMutation[]; total: number } | undefined>;
+  paginator?: boolean;
+  rowsAmount?: number;
+  preload?: boolean;
+  dataKey?: string;
+  showEditedIcon?: boolean;
+}>();
+
+const rows: Ref<number> = ref(props.rowsAmount || 10);
+const mutations = ref<FinancialMutation[]>(new Array(rows.value));
+const totalRecords = ref<number>(0);
+const isLoading: Ref<boolean> = ref(true);
+
+async function refresh() {
+  isLoading.value = true;
+  const result = await props.fetchPage(rows.value, 0);
+  if (!result) {
+    isLoading.value = false;
+    return;
+  }
+  mutations.value = result.rows;
+  totalRecords.value = result.total;
+  isLoading.value = false;
+}
+
+onMounted(async () => {
+  await refresh();
+  if (props.preload) void pl(mutations.value);
+});
+
+async function onPage(event: DataTablePageEvent) {
+  const result = await props.fetchPage(event.rows, event.first);
+  if (!result) return;
+  mutations.value = result.rows;
+}
+
+const openedMutationId = ref<number>();
+const openedMutationType = ref<FinancialMutationType>();
+const openedInactiveCostId = ref<number>();
+const isModalVisible = ref<boolean>(false);
+
+function openModal(id: number, type: FinancialMutationType, inactiveCostId?: number) {
+  if (type === FinancialMutationType.INACTIVE_ADMINISTRATIVE_COST) {
+    if (inactiveCostId !== undefined && inactiveCostId !== null) {
+      openedInactiveCostId.value = inactiveCostId;
+    }
+  } else {
+    openedMutationId.value = id;
+    openedMutationType.value = type;
+    isModalVisible.value = true;
+  }
+}
+
+function handleInactiveClose() {
+  openedInactiveCostId.value = undefined;
+}
+
+function handleInactiveDelete() {
+  openedInactiveCostId.value = undefined;
+  void refresh();
+}
+
+defineExpose({ refresh });
+</script>
+<style lang="scss" scoped></style>

--- a/apps/dashboard/src/components/mutations/MutationsTransfers.vue
+++ b/apps/dashboard/src/components/mutations/MutationsTransfers.vue
@@ -1,115 +1,25 @@
 <template>
-  <DataTable
-    lazy
-    :paginator="paginator"
-    :rows="rows"
-    :rows-per-page-options="[5, 10, 25, 50, 100]"
-    :total-records="totalRecords"
-    :value="mutations"
-    @page="onPage($event)"
-  >
-    <Column field="moment" :header="t('components.mutations.when')">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-6" />
-      </template>
-      <template v-else #body="mutation">
-        <span class="hidden sm:block">
-          {{ mutation.data.moment.toLocaleDateString(locale, { dateStyle: 'full' }) }}
-        </span>
-        <span class="sm:hidden whitespace-nowrap">
-          {{ mutation.data.moment.toLocaleDateString('nl-NL', { dateStyle: 'short' }) }}
-        </span>
-      </template>
-    </Column>
-
-    <Column field="type" :header="t('components.mutations.type')">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-6" />
-      </template>
-      <template v-else #body="mutation">
-        {{ getDescription(mutation.data) }}
-      </template>
-    </Column>
-
-    <Column field="amount" :header="t('components.mutations.amount')">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-3" />
-      </template>
-      <template v-else #body="mutation">
-        <div v-if="isIncreasingTransfer(mutation.data.type)" class="font-bold" style="color: #198754">
-          {{ formatPrice((mutation.data as FinancialMutation).amount) }}
-        </div>
-        <div
-          v-else-if="
-            isFine(mutation.data.type) || mutation.data.type === FinancialMutationType.INACTIVE_ADMINISTRATIVE_COST
-          "
-          class="font-bold"
-          style="color: #d40000"
-        >
-          {{ formatPrice((mutation.data as FinancialMutation).amount, true) }}
-        </div>
-        <div v-else>
-          {{ formatPrice((mutation.data as FinancialMutation).amount, true) }}
-        </div>
-      </template>
-    </Column>
-
-    <Column field="" style="width: 10%">
-      <template v-if="isLoading" #body>
-        <Skeleton class="h-1rem my-1 surface-300 w-3" />
-      </template>
-      <template v-else #body="mutation">
-        <i
-          class="cursor-pointer pi pi-info-circle"
-          @click="() => openModal(mutation.data.id, mutation.data.type, mutation.data.inactiveCostId)"
-        />
-      </template>
-    </Column>
-  </DataTable>
-
-  <ModalMutation
-    v-if="
-      openedMutationId &&
-      openedMutationType !== undefined &&
-      openedMutationType !== FinancialMutationType.INACTIVE_ADMINISTRATIVE_COST
-    "
-    :id="openedMutationId"
-    v-model:visible="isModalVisible"
-    :type="openedMutationType"
-    @deleted="refresh"
-  />
-  <ModalInactive
-    v-if="openedInactiveCostId"
-    :id="openedInactiveCostId"
-    @close="openedInactiveCostId = undefined"
-    @delete="
-      () => {
-        openedInactiveCostId = undefined;
-        void refresh();
-      }
-    "
-  />
+  <MutationsTable ref="tableRef" :fetch-page="fetchPage" :paginator="paginator" :rows-amount="rowsAmount">
+    <template #columns="{ isLoading }">
+      <Column field="type" :header="t('components.mutations.type')">
+        <template v-if="isLoading" #body>
+          <Skeleton class="h-1rem my-1 surface-300 w-6" />
+        </template>
+        <template v-else #body="mutation">
+          {{ getDescription(mutation.data) }}
+        </template>
+      </Column>
+    </template>
+  </MutationsTable>
 </template>
-
 <script lang="ts" setup>
-import DataTable, { type DataTablePageEvent } from 'primevue/datatable';
-import Column from 'primevue/column';
-import { onMounted, type Ref, ref } from 'vue';
+import { ref } from 'vue';
 import type { PaginatedTransferResponse, TransferResponse } from '@gewis/sudosos-client';
 import { useI18n } from 'vue-i18n';
-import { formatPrice } from '@/utils/formatterUtils';
-import {
-  type FinancialMutation,
-  FinancialMutationType,
-  parseTransfer,
-  getDescription,
-  isIncreasingTransfer,
-  isFine,
-} from '@/utils/mutationUtils';
-import ModalMutation from '@/components/mutations/mutationmodal/ModalMutation.vue';
-import ModalInactive from '@/components/mutations/mutationmodal/ModalInactive.vue';
+import { getDescription, parseTransfer } from '@/utils/mutationUtils';
+import MutationsTable from '@/components/mutations/MutationsTable.vue';
 
-const { t, locale } = useI18n();
+const { t } = useI18n();
 
 const props = defineProps<{
   getTransfers: (take: number, skip: number) => Promise<PaginatedTransferResponse | undefined>;
@@ -117,48 +27,20 @@ const props = defineProps<{
   rowsAmount?: number;
 }>();
 
-const rows: Ref<number> = ref(props.rowsAmount || 10);
-const mutations = ref<FinancialMutation[]>(new Array(rows.value));
-const totalRecords = ref<number>(0);
-const isLoading: Ref<boolean> = ref(true);
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+const tableRef = ref<InstanceType<typeof MutationsTable> | null>(null);
 
-async function refresh() {
-  isLoading.value = true;
-  const result = await props.getTransfers(rows.value, 0);
-  if (!result) {
-    isLoading.value = false;
-    return;
-  }
-  mutations.value = result.records.map((t: TransferResponse) => parseTransfer(t));
-  totalRecords.value = result._pagination.count || 0;
-  isLoading.value = false;
+async function fetchPage(take: number, skip: number) {
+  const result = await props.getTransfers(take, skip);
+  if (!result) return undefined;
+  return {
+    rows: result.records.map((t: TransferResponse) => parseTransfer(t)),
+    total: result._pagination.count || 0,
+  };
 }
 
-onMounted(async () => {
-  await refresh();
-});
-
-async function onPage(event: DataTablePageEvent) {
-  const result = await props.getTransfers(event.rows, event.first);
-  if (!result) return;
-  mutations.value = result.records.map((t: TransferResponse) => parseTransfer(t));
-}
-
-const openedMutationId = ref<number>();
-const openedMutationType = ref<FinancialMutationType>();
-const openedInactiveCostId = ref<number>();
-const isModalVisible = ref<boolean>(false);
-
-function openModal(id: number, type: FinancialMutationType, inactiveCostId?: number) {
-  if (type === FinancialMutationType.INACTIVE_ADMINISTRATIVE_COST) {
-    if (inactiveCostId !== undefined && inactiveCostId !== null) {
-      openedInactiveCostId.value = inactiveCostId;
-    }
-  } else {
-    openedMutationId.value = id;
-    openedMutationType.value = type;
-    isModalVisible.value = true;
-  }
+function refresh() {
+  return tableRef.value?.refresh();
 }
 
 defineExpose({ refresh });


### PR DESCRIPTION
# Description

The dashboard had four near-identical mutation table components (`MutationsBalance`, `MutationsPOS`, `MutationsSeller`, `MutationsTransfers`), each reimplementing the same table: lazy pagination, loading skeletons, the date column, amount color coding, an info-icon column, and the mutation/inactive-cost modal wiring. Small fixes had already drifted out of sync between variants - for example, only three of the four reset `isLoading` on a failed page fetch.

This PR pulls all of that shared behavior into one `MutationsTable.vue`. The four original components keep their existing public props (`getMutations`/`getTransfers`, `paginator`, `rowsAmount`, `preload`) and their own specific columns, but now just render `MutationsTable` and pass their extra columns through a scoped slot. I didn't have to touch any call sites.

Verified manually in the browser (admin, member, organ, and seller views) against a freshly seeded local backend: pagination, amount coloring (green for deposits, red for fines, default for transactions), the edited-icon on Balance, and the detail/inactive-cost modals all behave the same as before.

## Related issues/external references

Closes #847

## Types of changes

- Style _(Change that do not affect the functionality of the code)_