### PR TITLE
Don't let a failed settings fetch block auth restore on reload

### DIFF
--- a/apps/dashboard/src/utils/beforeLoadUtil.ts
+++ b/apps/dashboard/src/utils/beforeLoadUtil.ts
@@ -17,11 +17,13 @@ export default async function beforeLoad() {
 
   try {
     setupWebSocket();
-    await settingsStore.fetchKeys();
   } catch (e) {
     console.error(e);
-    return;
   }
+
+  await settingsStore.fetchKeys().catch((e) => {
+    console.error(e);
+  });
 
   await populateStoresFromToken(apiService).catch(() => {
     clearTokenInStorage();


### PR DESCRIPTION
# Description

`beforeLoad()` fetches Stripe/settings keys before doing anything else. If that call throws, the catch block logs the error and returns early, skipping `populateStoresFromToken()` for the rest of that page load.

`beforeLoad()` runs once on every fresh page load (hard reload or opening a deep link directly), so a logged-in user's auth store never got repopulated from their stored JWT whenever the settings fetch failed. The router guard then treats them as unauthenticated and bounces them to the login screen, even though their token in localStorage is still valid.

Locally this triggers on every hard reload once `STRIPE_PUBLIC_KEY` is unset, since `/v1/stripe/public` then 401s. The same early return would fire in production too if that settings fetch ever failed for an unrelated reason (backend restart, slow network, etc).

Fix: catch the `fetchKeys()` failure inline instead of returning early, so `populateStoresFromToken()` and the terms-of-service fetch always run regardless of whether the settings fetch succeeded. `setupWebSocket()` gets its own try/catch for the same reason.

Verified locally against a backend with no Stripe key configured: logged in, then hard-reloaded both the root route and a deep link (`/transaction`). Before the fix both bounced to the login screen; after the fix both stay on the authenticated page. The Stripe 401 still happens and gets logged, it just no longer blocks auth restoration.

## Related issues/external references

Fixes #852

## Types of changes

- Bug fix _(non-breaking change which fixes an issue)_