### PR TITLE
fix: modals closable with escape

### DIFF
--- a/apps/point-of-sale/src/components/AgeVerificationComponent.vue
+++ b/apps/point-of-sale/src/components/AgeVerificationComponent.vue
@@ -1,5 +1,13 @@
 <template>
-  <Dialog v-model:visible="visible" class="w-120" :closable="false" :dismissable-mask="false" :draggable="false" modal>
+  <Dialog
+    v-model:visible="visible"
+    class="w-120"
+    :closable="false"
+    :close-on-escape="false"
+    :dismissable-mask="false"
+    :draggable="false"
+    modal
+  >
     <div class="flex flex-col items-center gap-6 py-4">
       <p class="text-xl font-semibold text-center">Your cart contains alcoholic products.</p>
       <p class="text-center text-lg">Are you 18 years of age or older?</p>

--- a/apps/point-of-sale/src/components/AprilFoolsComponent.vue
+++ b/apps/point-of-sale/src/components/AprilFoolsComponent.vue
@@ -1,5 +1,13 @@
 <template>
-  <Dialog v-model:visible="visible" class="w-100" :closable="false" :dismissable-mask="false" :draggable="false" modal>
+  <Dialog
+    v-model:visible="visible"
+    class="w-100"
+    :closable="false"
+    :close-on-escape="false"
+    :dismissable-mask="false"
+    :draggable="false"
+    modal
+  >
     <div class="flex flex-col justify-center items-center mt-4 gap-4">
       <img alt="SudoSOS QR Code" class="h-72" src="@/assets/aprilfools.png" />
 

--- a/apps/point-of-sale/src/components/Cart/TerminalPaymentModal.vue
+++ b/apps/point-of-sale/src/components/Cart/TerminalPaymentModal.vue
@@ -3,6 +3,7 @@
     v-model:visible="visible"
     class="w-120"
     :closable="false"
+    :close-on-escape="false"
     :dismissable-mask="false"
     :draggable="false"
     header="Card payment"

--- a/apps/point-of-sale/src/components/TopUpWarningComponent.vue
+++ b/apps/point-of-sale/src/components/TopUpWarningComponent.vue
@@ -3,6 +3,7 @@
     v-model:visible="visible"
     class="w-[35rem]"
     :closable="false"
+    :close-on-escape="false"
     :dismissable-mask="false"
     :draggable="false"
     header="Please Top-Up your SudoSOS balance"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Fixes pin terminal softlock that occurred when pressing the escape button when a payment was pending on the pin terminal. This would close the modal, but not cancel the transaction.

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_